### PR TITLE
Add 'versionHeightOffset' for GitVersioning

### DIFF
--- a/tas-client/version.json
+++ b/tas-client/version.json
@@ -1,6 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
     "version": "0.1",
+    "versionHeightOffset": 30,
     "publicReleaseRefSpec": [
         "^refs/heads/main$",
         "^refs/heads/v\\d+(?:.\\d+)?$",

--- a/vscode-tas-client/version.json
+++ b/vscode-tas-client/version.json
@@ -1,6 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
     "version": "0.1",
+    "versionHeightOffset": 30,
     "publicReleaseRefSpec": [
         "^refs/heads/main$",
         "^refs/heads/v\\d+(?:.\\d+)?$",


### PR DESCRIPTION
Because of the switch from ADO to GitHub, the current git tree height is overlapping with previously released versions of the package. To make sure the new version numbers always exceed the old version numbers from packages built out of the old repo, we need to leverage the `versionHeightOffset` setting from Nerdbank.GitVersioning.