### PR TITLE
Remove features property from telemetry

### DIFF
--- a/tas-client-umd/README.md
+++ b/tas-client-umd/README.md
@@ -56,7 +56,6 @@ const tasClient = new TASClient({
 			telemetry: telemetry,
 			storageKey: storageKey,
 			keyValueStorage: keyValueStorage,
-			featuresTelemetryPropertyName: '<featuresTelemetryPropertyName>',
 			assignmentContextTelemetryPropertyName: '<assignmentContextTelemetryPropertyName>',
 			telemetryEventName: '<telemetryEventName>',
 			endpoint: '<tas-endpoint>',
@@ -64,7 +63,7 @@ const tasClient = new TASClient({
 		});
 ```
 
-`featuresTelemetryPropertyName` and `assignmentContextTelemetryPropertyName` are properties that are added to every telemetry event for experimentation result calculations.
+`assignmentContextTelemetryPropertyName` is a property that is added to every telemetry event for experimentation result calculations.
 
 `telemetryEventName` is the name of the event which is posted every time experiment data is queried.
 
@@ -258,12 +257,13 @@ declare module 'tas-client-umd' {
 		 */
 		filterProviders?: IExperimentationFilterProvider[];
 		/**
+		 * @deprecated This property is no longer used. You can get equivalent information from the assignment context property.
 		 * A string containing the name for the features telemetry property.
 		 * This option is implemented in IExperimentation Telemetry.
 		 * This options posts to the implementation a list of
 		 * available features for the client, separated by ';'
 		 */
-		featuresTelemetryPropertyName: string;
+		featuresTelemetryPropertyName?: string;
 		/**
 		 * A string containing the name for the assignment context telemetry property.
 		 * This option is implemented in IExperimentation Telemetry.
@@ -304,7 +304,6 @@ declare module 'tas-client-umd' {
 	 */
 	abstract class ExperimentationServiceBase implements IExperimentationService {
 		protected telemetry: IExperimentationTelemetry;
-		protected featuresTelemetryPropertyName: string;
 		protected assignmentContextTelemetryPropertyName: string;
 		protected telemetryEventName: string;
 		protected storageKey?: string | undefined;
@@ -319,7 +318,7 @@ declare module 'tas-client-umd' {
 		private _features;
 		private get features();
 		private set features(value);
-		constructor(telemetry: IExperimentationTelemetry, featuresTelemetryPropertyName: string, assignmentContextTelemetryPropertyName: string, telemetryEventName: string, storageKey?: string | undefined, storage?: IKeyValueStorage | undefined);
+		constructor(telemetry: IExperimentationTelemetry, assignmentContextTelemetryPropertyName: string, telemetryEventName: string, storageKey?: string | undefined, storage?: IKeyValueStorage | undefined);
 		/**
 		 * Gets all the features from the provider sources (not cache).
 		 * It returns these features and will also update the providers to have the latest features cached.
@@ -396,13 +395,12 @@ declare module 'tas-client-umd' {
 		protected telemetry: IExperimentationTelemetry;
 		protected filterProviders: IExperimentationFilterProvider[];
 		protected refreshRateMs: number;
-		protected featuresTelemetryPropertyName: string;
 		protected assignmentContextTelemetryPropertyName: string;
 		protected telemetryEventName: string;
 		protected storageKey?: string | undefined;
 		protected storage?: IKeyValueStorage | undefined;
 		private pollingService?;
-		constructor(telemetry: IExperimentationTelemetry, filterProviders: IExperimentationFilterProvider[], refreshRateMs: number, featuresTelemetryPropertyName: string, assignmentContextTelemetryPropertyName: string, telemetryEventName: string, storageKey?: string | undefined, storage?: IKeyValueStorage | undefined);
+		constructor(telemetry: IExperimentationTelemetry, filterProviders: IExperimentationFilterProvider[], refreshRateMs: number, assignmentContextTelemetryPropertyName: string, telemetryEventName: string, storageKey?: string | undefined, storage?: IKeyValueStorage | undefined);
 		protected init(): void;
 		/**
 		 * Wrapper that will reset the polling intervals whenever the feature data is fetched manually.

--- a/tas-client-umd/tas-client-umd.d.ts
+++ b/tas-client-umd/tas-client-umd.d.ts
@@ -186,12 +186,13 @@ declare module 'tas-client-umd' {
 		 */
 		filterProviders?: IExperimentationFilterProvider[];
 		/**
+		 * @deprecated This property is no longer used. You can get equivalent information from the assignment context property.
 		 * A string containing the name for the features telemetry property.
 		 * This option is implemented in IExperimentation Telemetry.
 		 * This options posts to the implementation a list of
 		 * available features for the client, separated by ';'
 		 */
-		featuresTelemetryPropertyName: string;
+		featuresTelemetryPropertyName?: string;
 		/**
 		 * A string containing the name for the assignment context telemetry property.
 		 * This option is implemented in IExperimentation Telemetry.
@@ -232,7 +233,6 @@ declare module 'tas-client-umd' {
 	 */
 	abstract class ExperimentationServiceBase implements IExperimentationService {
 		protected telemetry: IExperimentationTelemetry;
-		protected featuresTelemetryPropertyName: string;
 		protected assignmentContextTelemetryPropertyName: string;
 		protected telemetryEventName: string;
 		protected storageKey?: string | undefined;
@@ -247,7 +247,7 @@ declare module 'tas-client-umd' {
 		private _features;
 		private get features();
 		private set features(value);
-		constructor(telemetry: IExperimentationTelemetry, featuresTelemetryPropertyName: string, assignmentContextTelemetryPropertyName: string, telemetryEventName: string, storageKey?: string | undefined, storage?: IKeyValueStorage | undefined);
+		constructor(telemetry: IExperimentationTelemetry, assignmentContextTelemetryPropertyName: string, telemetryEventName: string, storageKey?: string | undefined, storage?: IKeyValueStorage | undefined);
 		/**
 		 * Gets all the features from the provider sources (not cache).
 		 * It returns these features and will also update the providers to have the latest features cached.
@@ -324,13 +324,12 @@ declare module 'tas-client-umd' {
 		protected telemetry: IExperimentationTelemetry;
 		protected filterProviders: IExperimentationFilterProvider[];
 		protected refreshRateMs: number;
-		protected featuresTelemetryPropertyName: string;
 		protected assignmentContextTelemetryPropertyName: string;
 		protected telemetryEventName: string;
 		protected storageKey?: string | undefined;
 		protected storage?: IKeyValueStorage | undefined;
 		private pollingService?;
-		constructor(telemetry: IExperimentationTelemetry, filterProviders: IExperimentationFilterProvider[], refreshRateMs: number, featuresTelemetryPropertyName: string, assignmentContextTelemetryPropertyName: string, telemetryEventName: string, storageKey?: string | undefined, storage?: IKeyValueStorage | undefined);
+		constructor(telemetry: IExperimentationTelemetry, filterProviders: IExperimentationFilterProvider[], refreshRateMs: number, assignmentContextTelemetryPropertyName: string, telemetryEventName: string, storageKey?: string | undefined, storage?: IKeyValueStorage | undefined);
 		protected init(): void;
 		/**
 		 * Wrapper that will reset the polling intervals whenever the feature data is fetched manually.

--- a/tas-client/README.md
+++ b/tas-client/README.md
@@ -17,7 +17,6 @@ const tasClient = new TASClient({
 			telemetry: telemetry,
 			storageKey: storageKey,
 			keyValueStorage: keyValueStorage,
-			featuresTelemetryPropertyName: '<featuresTelemetryPropertyName>',
 			assignmentContextTelemetryPropertyName: '<assignmentContextTelemetryPropertyName>',
 			telemetryEventName: '<telemetryEventName>',
 			endpoint: '<tas-endpoint>',

--- a/tas-client/src/contracts/ExperimentationServiceConfig.ts
+++ b/tas-client/src/contracts/ExperimentationServiceConfig.ts
@@ -18,12 +18,13 @@ export interface ExperimentationServiceConfig {
      */
     filterProviders?: IExperimentationFilterProvider[];
     /**
+     * @deprecated This property is no longer used. You can get equivalent information from the assignment context property.
      * A string containing the name for the features telemetry property.
      * This option is implemented in IExperimentation Telemetry.
      * This options posts to the implementation a list of
      * available features for the client, separated by ';'
      */
-    featuresTelemetryPropertyName: string;
+    featuresTelemetryPropertyName?: string;
     /**
      * A string containing the name for the assignment context telemetry property.
      * This option is implemented in IExperimentation Telemetry.

--- a/tas-client/src/tas-client/ExperimentationService.ts
+++ b/tas-client/src/tas-client/ExperimentationService.ts
@@ -28,7 +28,6 @@ export class ExperimentationService extends ExperimentationServiceAutoPolling {
                 ? options.refetchInterval
                 : // If no fetch interval is provided, refetch functionality is turned off.
                   0,
-            options.featuresTelemetryPropertyName,
             options.assignmentContextTelemetryPropertyName,
             options.telemetryEventName,
             options.storageKey,

--- a/tas-client/src/tas-client/ExperimentationServiceAutoPolling.ts
+++ b/tas-client/src/tas-client/ExperimentationServiceAutoPolling.ts
@@ -20,13 +20,12 @@ export abstract class ExperimentationServiceAutoPolling extends ExperimentationS
         protected telemetry: IExperimentationTelemetry,
         protected filterProviders: IExperimentationFilterProvider[],
         protected refreshRateMs: number,
-        protected featuresTelemetryPropertyName: string,
         protected assignmentContextTelemetryPropertyName: string,
         protected telemetryEventName: string,
         protected storageKey?: string,
         protected storage?: IKeyValueStorage,
     ) {
-        super(telemetry, featuresTelemetryPropertyName, assignmentContextTelemetryPropertyName, telemetryEventName, storageKey, storage);
+        super(telemetry, assignmentContextTelemetryPropertyName, telemetryEventName, storageKey, storage);
         // Excluding 0 since it allows to turn off the auto polling.
         if (refreshRateMs < 1000 && refreshRateMs !== 0) {
             throw new Error(

--- a/tas-client/src/tas-client/ExperimentationServiceBase.ts
+++ b/tas-client/src/tas-client/ExperimentationServiceBase.ts
@@ -39,14 +39,12 @@ export abstract class ExperimentationServiceBase implements IExperimentationServ
          * If an implementation of telemetry exists, we set the shared property.
          */
         if (this.telemetry) {
-            this.telemetry.setSharedProperty(this.featuresTelemetryPropertyName, this.features.features.join(';'));
             this.telemetry.setSharedProperty(this.assignmentContextTelemetryPropertyName, this.features.assignmentContext);
         }
     }
 
     constructor(
         protected telemetry: IExperimentationTelemetry,
-        protected featuresTelemetryPropertyName: string,
         protected assignmentContextTelemetryPropertyName: string,
         protected telemetryEventName: string,
         protected storageKey?: string,

--- a/tas-client/test/ExperimentationService.test.ts
+++ b/tas-client/test/ExperimentationService.test.ts
@@ -304,7 +304,7 @@ describe('Get features from multiple providers that differ in polling intervals 
     // Third result should be: ['ness', 'mario', 'lucario', 'ike', 'kirby', 'falco']
     it('should automatically refetch the third result and update cache.', async () => {
         await new Promise<void>((resolve) => {
-            setTimeout(() => resolve(), 1200); // 1200 ms, because it takes 1000 ms to do the polling, and 200ms to complete the fetch.
+            setTimeout(() => resolve(), 1500); // 1200 ms, because it takes 1000 ms to do the polling, and 200ms to complete the fetch, + 300ms buffer.
         });
 
         let features = await storage.getValue<FeatureData>('StorageKey');
@@ -408,13 +408,13 @@ describe('Telemetry tests', () => {
     it('Shared properties should be set on isCachedFlightEnabled', async () => {
         const experimentationTelemetryMock = new ExperimentationTelemetryMock();
         const keyValueStorageMock = new KeyValueStorageMock();
-        keyValueStorageMock.setValue<FeatureData>('StorageKey', { features: ['testFlight'], assignmentContext: '', configs: [] });
+        keyValueStorageMock.setValue<FeatureData>('StorageKey', { features: ['testFlight'], assignmentContext: 'tf', configs: [] });
         const service = new ExperimentationServiceMock([], [], 10000, experimentationTelemetryMock, keyValueStorageMock);
 
         await service.isCachedFlightEnabled('testFlight');
 
-        expect('testFlight').to.equal(experimentationTelemetryMock.sharedProperties.get('FeaturesTelemetryEventName'));
-        expect('testFlight').to.equal(experimentationTelemetryMock.postedEvents[0].sharedProperties.get('FeaturesTelemetryEventName'));
+        expect('tf').to.equal(experimentationTelemetryMock.sharedProperties.get('AssignmentContextTelemetryEventName'));
+        expect('tf').to.equal(experimentationTelemetryMock.postedEvents[0].sharedProperties.get('AssignmentContextTelemetryEventName'));
     });
 });
 

--- a/tas-client/test/WebApi.test.ts
+++ b/tas-client/test/WebApi.test.ts
@@ -22,7 +22,6 @@ describe('Web Api Test', () => {
         storageKey: 'test_features',
         endpoint: 'https://default.exp-tas.com/vscode/ab',
         refetchInterval: 0,
-        featuresTelemetryPropertyName: 'FeaturesTelemetryName',
         assignmentContextTelemetryPropertyName: 'AssignmentContextTelemetryName',
         telemetryEventName: 'feature_queried',
     });
@@ -33,7 +32,6 @@ describe('Web Api Test', () => {
     let experimentationServiceWithoutFilters = new ExperimentationService({
         telemetry: new ExperimentationTelemetryMock(),
         endpoint: 'https://default.exp-tas.com/vscode/ab',
-        featuresTelemetryPropertyName: 'FeaturesTelemetryName',
         assignmentContextTelemetryPropertyName: 'AssignmentContextTelemetryName',
         telemetryEventName: 'event',
     });

--- a/tas-client/test/mocks/ExperimentationServiceMock.ts
+++ b/tas-client/test/mocks/ExperimentationServiceMock.ts
@@ -25,7 +25,6 @@ export class ExperimentationServiceMock extends ExperimentationServiceAutoPollin
             experimentationTelemetry || new ExperimentationTelemetryMock(),
             [new ExperimentationFilterProviderMock()],
             pollingInterval,
-            'FeaturesTelemetryEventName',
             'AssignmentContextTelemetryEventName',
             'TelemetryName',
             'StorageKey',
@@ -41,9 +40,6 @@ export class ExperimentationServiceMock extends ExperimentationServiceAutoPollin
             );
         }
 
-        if (this.featuresTelemetryPropertyName == null) {
-            this.featuresTelemetryPropertyName = 'MockFeaturesTelemetryProperty';
-        }
         if (this.assignmentContextTelemetryPropertyName == null) {
             this.assignmentContextTelemetryPropertyName = 'MockAssignmentContextTelemetryProperty';
         }

--- a/tas-client/test/mocks/FilteredExperimentationServiceMock.ts
+++ b/tas-client/test/mocks/FilteredExperimentationServiceMock.ts
@@ -20,7 +20,6 @@ export class FilteredExperimentationServiceMock extends ExperimentationServiceAu
             new ExperimentationTelemetryMock(),
             filterProviders,
             0,
-            'FeaturesTelemetryEventName',
             'AssignmentContextTelemetryEventName',
             'TelemetryName',
             'StorageKey',
@@ -40,9 +39,6 @@ export class FilteredExperimentationServiceMock extends ExperimentationServiceAu
         );
         this.addFeatureProvider(this.featureProvider);
 
-        if (this.featuresTelemetryPropertyName == null) {
-            this.featuresTelemetryPropertyName = 'MockFeaturesTelemetryProperty';
-        }
         if (this.assignmentContextTelemetryPropertyName == null) {
             this.assignmentContextTelemetryPropertyName = 'MockAssignmentContextTelemetryProperty';
         }

--- a/vscode-tas-client/src/vscode-tas-client/VSCodeTasClient.ts
+++ b/vscode-tas-client/src/vscode-tas-client/VSCodeTasClient.ts
@@ -17,7 +17,6 @@ import TelemetryDisabledExperimentationService from './TelemetryDisabledExperime
 
 const endpoint: string = 'https://default.exp-tas.com/vscode/ab';
 const telemetryEventName = 'query-expfeature';
-const featuresTelemetryPropertyName = 'VSCode.ABExp.Features';
 const assignmentContextTelemetryPropertyName = 'abexp.assignmentcontext';
 const storageKey = 'VSCode.ABExp.FeatureData';
 const refetchInterval = 1000 * 60 * 30; // By default it's set up to 30 minutes.
@@ -64,7 +63,7 @@ export function getExperimentationService(
         telemetry: telemetry,
         storageKey: storageKey,
         keyValueStorage: keyValueStorage,
-        featuresTelemetryPropertyName: featuresTelemetryPropertyName,
+        featuresTelemetryPropertyName: '',
         assignmentContextTelemetryPropertyName: assignmentContextTelemetryPropertyName,
         telemetryEventName: telemetryEventName,
         endpoint: endpoint,


### PR DESCRIPTION
This property doesn't provide any information that isn't available in the assignment context property and can make telemetry events significantly larger.