### PR TITLE
Disable API feature provider when network errors out

### DIFF
--- a/tas-client/src/tas-client/FeatureProvider/TasApiFeatureProvider.ts
+++ b/tas-client/src/tas-client/FeatureProvider/TasApiFeatureProvider.ts
@@ -4,10 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IExperimentationFilterProvider } from '../../contracts/IExperimentationFilterProvider';
-import { FetchError, FetchResult, HttpClient } from '../Util/HttpClient';
 import { IExperimentationTelemetry } from '../../contracts/IExperimentationTelemetry';
+import { FetchResult, HttpClient } from '../Util/HttpClient';
 import { FilteredFeatureProvider } from './FilteredFeatureProvider';
-import { FeatureData, ConfigData } from './IFeatureProvider';
+import { ConfigData, FeatureData } from './IFeatureProvider';
 
 export const TASAPI_FETCHERROR_EVENTNAME = 'call-tas-error';
 const ERROR_TYPE = 'ErrorType';
@@ -15,6 +15,8 @@ const ERROR_TYPE = 'ErrorType';
  * Feature provider implementation that calls the TAS web service to get the most recent active features.
  */
 export class TasApiFeatureProvider extends FilteredFeatureProvider {
+    // Tracks whether or not we've ever received a network error. If we do we will disable the feature provider
+    private disableDueToNetworkError: boolean = false;
     constructor(
         protected httpClient: HttpClient,
         protected telemetry: IExperimentationTelemetry,
@@ -27,6 +29,10 @@ export class TasApiFeatureProvider extends FilteredFeatureProvider {
      * Method that handles fetching of latest data (in this case, flights) from the provider.
      */
     public async fetch(): Promise<FeatureData> {
+        if (this.disableDueToNetworkError) {
+            // This is caught by the fetch caller and no-opted on so throwing is expected
+            throw new Error('Feature provider disabled due to network error');
+        }
         // We get the filters that will be sent as headers.
         let filters = this.getFilters();
         let headers: any = {};
@@ -43,20 +49,24 @@ export class TasApiFeatureProvider extends FilteredFeatureProvider {
 
         try {
             response = await this.httpClient.get({ headers: headers });
-        } catch (error) {
-            const fetchError = error as FetchError;
+        } catch (error: any) {
             const properties: Map<string, string> = new Map();
-            if (fetchError.responseReceived && !fetchError.responseOk) {
+            if (error?.responseReceived && !error?.responseOk) {
                 // The request was made and the server responded with a status code
                 // that falls out of the range of 2xx
                 properties.set(ERROR_TYPE, 'ServerError');
-            } else if (fetchError.responseReceived === false) {
+            } else if (error?.responseReceived === false) {
                 // The request was made but no response was received
                 properties.set(ERROR_TYPE, 'NoResponse');
+            } else if (error?.cause?.code === 'UND_ERR_CONNECT_TIMEOUT') {
+                // The request was made but timed out prior to a respoonse being received
+                properties.set(ERROR_TYPE, 'TimeoutError');
             } else {
                 // Something happened in setting up the request that triggered an Error
                 properties.set(ERROR_TYPE, 'GenericError');
             }
+            // Exp is not critical so disabling it after a fetch error is best otherwise we will consistently block when things like timeouts occur.
+            this.disableDueToNetworkError = true;
             this.telemetry.postEvent(TASAPI_FETCHERROR_EVENTNAME, properties);
         }
 


### PR DESCRIPTION
When corporate firewalls block the exp service this can cause the endpoint to time out. Sinc a lot of callers await exp via `getTreatmentVariableAsync` we effectively produce a ~10 second delay (how long it takes to timeout) at every await call. Since exp is non critical instead when the network errors out we should cease to make request to the exp endpoint for the duration of the session as things like a firewall block, empty response, or network errors are likely to be persistent for the duration of the session.
