### PR TITLE
Add new GH TAS assignments (POST /api/v1/assignments) endpoint support

### DIFF
--- a/tas-client/package-lock.json
+++ b/tas-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tas-client",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tas-client",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.19.15",

--- a/tas-client/package.json
+++ b/tas-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tas-client",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/tas-client/src/contracts/ExperimentationServiceConfig.ts
+++ b/tas-client/src/contracts/ExperimentationServiceConfig.ts
@@ -8,11 +8,51 @@ import { IExperimentationFilterProvider } from './IExperimentationFilterProvider
 import { IKeyValueStorage } from './IKeyValueStorage.js';
 
 /**
+ * Minimal response shape returned by {@link AssignmentsFetchFn}, matching the subset of the
+ * Fetch API the assignments provider needs.
+ */
+export interface IAssignmentsFetchResponse {
+    readonly status: number;
+    json(): Promise<any>;
+}
+
+/**
+ * Optional custom transport for the new TAS assignments API. When provided, the assignments
+ * provider uses this instead of its built-in HTTP client, so hosts can route the request
+ * through their own networking stack (proxy handling, retries, user-agent, etc.).
+ */
+export type AssignmentsFetchFn = (
+    url: string,
+    init: { method: 'POST'; headers: Record<string, string>; body: string },
+) => Promise<IAssignmentsFetchResponse>;
+
+/**
  * Options that include the implementations of the Experimentation service.
  */
 export interface ExperimentationServiceConfig {
     telemetry: IExperimentationTelemetry;
     endpoint: string;
+    /**
+     * Optional endpoint for the new TAS assignments API (POST /api/v1/assignments).
+     * When set, a request is sent to this endpoint in parallel with the main endpoint and
+     * its assignments are merged into the active feature set (new values take precedence
+     * for overlapping variables). On failure it contributes nothing and the main endpoint's
+     * results are preserved.
+     */
+    assignmentsEndpoint?: string;
+    /**
+     * Filter providers used exclusively for the new TAS assignments API
+     * ({@link assignmentsEndpoint}). These emit the assignments-API parameter names
+     * directly, so the new endpoint never receives the legacy {@link filterProviders}
+     * keys. When {@link assignmentsEndpoint} is set but this is omitted, the legacy
+     * {@link filterProviders} are used as a fallback.
+     */
+    assignmentsFilterProviders?: IExperimentationFilterProvider[];
+    /**
+     * Optional custom transport for the assignments endpoint. When provided, it is used
+     * instead of the built-in HTTP client for the {@link assignmentsEndpoint} request.
+     */
+    assignmentsFetch?: AssignmentsFetchFn;
     /**
      * If there's any specific filter provider for the endpoint filters, it's defined or added into this list.
      */

--- a/tas-client/src/index.ts
+++ b/tas-client/src/index.ts
@@ -8,4 +8,4 @@ export { IExperimentationService } from './contracts/IExperimentationService.js'
 export { IExperimentationTelemetry } from './contracts/IExperimentationTelemetry.js';
 export { IKeyValueStorage } from './contracts/IKeyValueStorage.js';
 export { ExperimentationService } from './tas-client/ExperimentationService.js';
-export { ExperimentationServiceConfig } from './contracts/ExperimentationServiceConfig.js';
+export { ExperimentationServiceConfig, AssignmentsFetchFn, IAssignmentsFetchResponse } from './contracts/ExperimentationServiceConfig.js';

--- a/tas-client/src/tas-client/ExperimentationService.ts
+++ b/tas-client/src/tas-client/ExperimentationService.ts
@@ -5,6 +5,7 @@
 
 import { IFeatureProvider } from './FeatureProvider/IFeatureProvider.js';
 import { TasApiFeatureProvider } from './FeatureProvider/TasApiFeatureProvider.js';
+import { AssignmentsApiFeatureProvider } from './FeatureProvider/AssignmentsApiFeatureProvider.js';
 import { HttpClient } from './Util/HttpClient.js';
 import { ExperimentationServiceConfig } from '../contracts/ExperimentationServiceConfig.js';
 import { ExperimentationServiceAutoPolling } from './ExperimentationServiceAutoPolling.js';
@@ -25,7 +26,7 @@ export class ExperimentationService extends ExperimentationServiceAutoPolling {
             options.refetchInterval != null
                 ? options.refetchInterval
                 : // If no fetch interval is provided, refetch functionality is turned off.
-                  0,
+                0,
             options.assignmentContextTelemetryPropertyName,
             options.telemetryEventName,
             options.storageKey,
@@ -46,6 +47,23 @@ export class ExperimentationService extends ExperimentationServiceAutoPolling {
                 this.filterProviders,
             ),
         );
+
+        // If a new assignments endpoint is configured, add a provider that calls the new
+        // TAS assignments API in parallel and whose assignments are merged with the legacy
+        // provider's results (new values win for overlapping variables). It uses its own
+        // filter providers (which emit the new assignments-API parameter names) so the
+        // legacy keys never reach it.
+        if (this.options.assignmentsEndpoint) {
+            this.addFeatureProvider(
+                new AssignmentsApiFeatureProvider(
+                    new HttpClient(this.options.assignmentsEndpoint),
+                    this.telemetry,
+                    this.options.assignmentsFilterProviders ?? this.filterProviders,
+                    this.options.assignmentsEndpoint,
+                    this.options.assignmentsFetch,
+                ),
+            );
+        }
 
         // This will start polling the TAS.
         super.init();

--- a/tas-client/src/tas-client/ExperimentationServiceBase.ts
+++ b/tas-client/src/tas-client/ExperimentationServiceBase.ts
@@ -105,7 +105,7 @@ export abstract class ExperimentationServiceBase implements IExperimentationServ
         } catch {
             // Fetching features threw error. Can happen if not connected to the internet, e.g.
         }
-        
+
         this.fetchPromise = undefined;
 
         if (this.resolveInitialFetchPromise) {
@@ -149,7 +149,14 @@ export abstract class ExperimentationServiceBase implements IExperimentationServ
                     features.configs.push(config);
                 }
             }
-            features.assignmentContext += result.assignmentContext;
+            if (result.assignmentContext) {
+                // Join contexts from multiple providers with a ';' so downstream consumers
+                // that split on ';' do not merge two providers' segments into one token.
+                if (features.assignmentContext && !features.assignmentContext.endsWith(';')) {
+                    features.assignmentContext += ';';
+                }
+                features.assignmentContext += result.assignmentContext;
+            }
         }
 
         /**
@@ -171,7 +178,7 @@ export abstract class ExperimentationServiceBase implements IExperimentationServ
         let cachedFeatureData: FeatureData | undefined;
         if (this.storage) {
             cachedFeatureData = await this.storage.getValue<FeatureData>(this.storageKey!);
-            // When updating from an older version of tas-client, configs may be undefined 
+            // When updating from an older version of tas-client, configs may be undefined
             if (cachedFeatureData !== undefined && cachedFeatureData.configs === undefined) {
                 cachedFeatureData.configs = [];
             }

--- a/tas-client/src/tas-client/FeatureProvider/AssignmentsApiFeatureProvider.ts
+++ b/tas-client/src/tas-client/FeatureProvider/AssignmentsApiFeatureProvider.ts
@@ -1,0 +1,225 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IExperimentationFilterProvider } from '../../contracts/IExperimentationFilterProvider.js';
+import { FetchError, FetchResult, HttpClient } from '../Util/HttpClient.js';
+import { IExperimentationTelemetry } from '../../contracts/IExperimentationTelemetry.js';
+import { AssignmentsFetchFn } from '../../contracts/ExperimentationServiceConfig.js';
+import { FilteredFeatureProvider } from './FilteredFeatureProvider.js';
+import { FeatureData } from './IFeatureProvider.js';
+
+export const ASSIGNMENTS_FETCHERROR_EVENTNAME = 'call-assignments-error';
+export const ASSIGNMENTS_VALIDATION_EVENTNAME = 'assignments-validation';
+const ERROR_TYPE = 'ErrorType';
+
+/**
+ * Feature provider that calls the new TAS assignments API (POST /api/v1/assignments)
+ * in parallel with the existing TAS provider.
+ *
+ * Its parsed assignments are merged with the legacy provider's results by the base
+ * service: because this provider is registered after the legacy one, variables from the
+ * new endpoint override/augment the legacy ones for the same config. On any failure it
+ * resolves with empty feature data and never throws, so a problem with the new endpoint
+ * cannot wipe out the legacy (authoritative) provider's results.
+ */
+export class AssignmentsApiFeatureProvider extends FilteredFeatureProvider {
+    /**
+     * Config id under which the flat `featureVariables` map is exposed. Both VS Code core
+     * and the Copilot extension query treatment variables under the `vscode` config.
+     */
+    private static readonly CONFIG_ID = 'vscode';
+    constructor(
+        protected httpClient: HttpClient,
+        protected telemetry: IExperimentationTelemetry,
+        protected filterProviders: IExperimentationFilterProvider[],
+        protected endpoint?: string,
+        protected fetchFn?: AssignmentsFetchFn,
+    ) {
+        super(telemetry, filterProviders);
+    }
+
+    private static readonly EMPTY_FEATURE_DATA: FeatureData = {
+        features: [],
+        assignmentContext: '',
+        configs: [],
+    };
+
+    /**
+     * Calls the new assignments API and returns its assignments as feature data to be
+     * merged with the legacy provider. Never throws; on any failure it returns empty
+     * feature data so the legacy provider's results are preserved.
+     */
+    public async fetch(): Promise<FeatureData> {
+        const userParams = this.buildUserParams();
+
+        // The API requires at least one userParam. If we have none, skip the call.
+        if (Object.keys(userParams).length === 0) {
+            return AssignmentsApiFeatureProvider.EMPTY_FEATURE_DATA;
+        }
+
+        const requestBody: AssignmentRequest = { userParams };
+
+        let responseData: AssignmentResponse;
+        try {
+            if (this.fetchFn) {
+                // Host-provided transport (e.g. VS Code fetcher service).
+                const res = await this.fetchFn(this.endpoint!, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(requestBody),
+                });
+                if (res.status < 200 || res.status > 299) {
+                    this.postErrorTelemetry(new FetchError('Response not ok', true, false));
+                    return AssignmentsApiFeatureProvider.EMPTY_FEATURE_DATA;
+                }
+                responseData = (await res.json()) as AssignmentResponse;
+            } else {
+                const response: FetchResult = await this.httpClient.post({ body: requestBody });
+                responseData = response.data as AssignmentResponse;
+            }
+        } catch (error) {
+            this.postErrorTelemetry(error as FetchError);
+            return AssignmentsApiFeatureProvider.EMPTY_FEATURE_DATA;
+        }
+
+        try {
+            const properties: Map<string, string> = new Map();
+            properties.set(
+                'FeatureVariableCount',
+                String(Object.keys(responseData.featureVariables || {}).length),
+            );
+            properties.set(
+                'AssignedVariantCount',
+                String((responseData.assignedVariants || []).length),
+            );
+            properties.set('DataVersion', String(responseData.dataVersion));
+            properties.set('AssignmentContext', responseData.assignmentContext || '');
+            this.telemetry.postEvent(ASSIGNMENTS_VALIDATION_EVENTNAME, properties);
+        } catch {
+            // Validation telemetry must never affect feature assignment.
+        }
+
+        // Merge the new endpoint's assignments into the active feature set.
+        return AssignmentsApiFeatureProvider.toFeatureData(responseData);
+    }
+
+    /**
+     * Maps an assignments-API response into the `FeatureData` shape consumed by the base
+     * service. The flat `featureVariables` map is exposed as the parameters of a single
+     * `vscode` config so that `getTreatmentVariable('vscode', name)` resolves against it.
+     * Truthy-valued variables are also listed as enabled flights. The legacy `cf` suffix
+     * convention is intentionally not applied to the new endpoint.
+     */
+    private static toFeatureData(response: AssignmentResponse): FeatureData {
+        const featureVariables = response.featureVariables || {};
+        const parameters: { [key: string]: boolean | number | string } = {};
+        const features: string[] = [];
+        for (const key of Object.keys(featureVariables)) {
+            const value = AssignmentsApiFeatureProvider.coerce(featureVariables[key]);
+            parameters[key] = value;
+            if (value && !features.includes(key)) {
+                features.push(key);
+            }
+        }
+
+        return {
+            features,
+            assignmentContext: response.assignmentContext || '',
+            configs:
+                Object.keys(parameters).length > 0
+                    ? [{ Id: AssignmentsApiFeatureProvider.CONFIG_ID, Parameters: parameters }]
+                    : [],
+        };
+    }
+
+    /**
+     * The assignments API returns all variable values as strings. Coerce `"true"`/`"false"`
+     * to booleans and numeric strings to numbers so treatment lookups match the typed
+     * values returned by the legacy provider.
+     */
+    private static coerce(value: string): boolean | number | string {
+        if (value === 'true') {
+            return true;
+        }
+        if (value === 'false') {
+            return false;
+        }
+        if (value !== '' && !isNaN(Number(value))) {
+            return Number(value);
+        }
+        return value;
+    }
+
+    /**
+     * Builds the userParams map from the configured filter providers. Null/empty values
+     * are dropped and the map is capped at 50 entries per the API contract.
+     */
+    private buildUserParams(): Record<string, string> {
+        const filters = this.getFilters();
+        const userParams: Record<string, string> = {};
+        for (const key of filters.keys()) {
+            const value = filters.get(key);
+            if (value === undefined || value === null || value === '') {
+                continue;
+            }
+            if (Object.keys(userParams).length >= 50) {
+                break;
+            }
+            userParams[key] = String(value);
+        }
+        return userParams;
+    }
+
+    private postErrorTelemetry(fetchError: FetchError): void {
+        const properties: Map<string, string> = new Map();
+        if (fetchError.responseReceived && !fetchError.responseOk) {
+            properties.set(ERROR_TYPE, 'ServerError');
+        } else if (fetchError.responseReceived === false) {
+            properties.set(ERROR_TYPE, 'NoResponse');
+        } else {
+            properties.set(ERROR_TYPE, 'GenericError');
+        }
+        this.telemetry.postEvent(ASSIGNMENTS_FETCHERROR_EVENTNAME, properties);
+    }
+}
+
+/**
+ * Request body for POST /api/v1/assignments.
+ */
+export interface AssignmentRequest {
+    /**
+     * Key-value pairs for audience filtering and randomization. At least one entry required.
+     */
+    userParams: Record<string, string>;
+    /**
+     * Experiment subscription scopes to filter evaluation.
+     */
+    scopes?: string[];
+    /**
+     * Variant names to force-assign.
+     */
+    requiredVariants?: string[];
+    /**
+     * Variant names to block from assignment.
+     */
+    blockedVariants?: string[];
+}
+
+/**
+ * Response body for POST /api/v1/assignments.
+ */
+export interface AssignmentResponse {
+    featureVariables: Record<string, string>;
+    assignedVariants: AssignedVariant[];
+    dataVersion: number;
+    assignmentContext: string;
+}
+
+export interface AssignedVariant {
+    name: string;
+    numberline: string;
+    isForced: boolean;
+    variantAllocationId: number;
+}

--- a/tas-client/src/tas-client/Util/HttpClient.ts
+++ b/tas-client/src/tas-client/Util/HttpClient.ts
@@ -7,6 +7,10 @@ export interface RequestConfig {
     headers?: Record<string, string>;
 }
 
+export interface PostRequestConfig extends RequestConfig {
+    body?: unknown;
+}
+
 export interface FetchResult {
     data: any;
 }
@@ -32,6 +36,14 @@ export class HttpClient {
             return this.nodeGet(config);
         } else {
             return this.webGet(config);
+        }
+    }
+
+    public async post(config?: PostRequestConfig | undefined): Promise<FetchResult> {
+        if (this.useNodeModules) {
+            return this.nodePost(config);
+        } else {
+            return this.webPost(config);
         }
     }
 
@@ -73,6 +85,72 @@ export class HttpClient {
         const response = await fetch(this.endpoint, {
             method: 'GET',
             headers: config?.headers,
+        });
+
+        if (!response) {
+            throw new FetchError('No response received', false);
+        }
+
+        if (!response.ok) {
+            throw new FetchError('Response not ok', true, false);
+        }
+
+        const data = await response.json();
+        if (!data) {
+            throw new FetchError('No data received', false);
+        }
+        return { data };
+    }
+
+    private async nodePost(config?: PostRequestConfig | undefined): Promise<FetchResult> {
+        const http = await import('http');
+        const https = await import('https');
+        const payload = JSON.stringify(config?.body ?? {});
+        return new Promise<FetchResult>((resolve, reject) => {
+            const headers: Record<string, string> = {
+                'Content-Type': 'application/json',
+                'Content-Length': Buffer.byteLength(payload).toString(),
+                ...(config?.headers || {}),
+            };
+            const req = (this.endpoint.startsWith('http:') ? http : https).request(
+                this.endpoint,
+                { method: 'POST', headers },
+                (res) => {
+                    if (res.statusCode! < 200 || res.statusCode! > 299) {
+                        reject(new FetchError('Response not ok', true, false));
+                    } else {
+                        res.on('error', reject);
+                        const chunks: Buffer[] = [];
+                        res.on('data', (chunk) => chunks.push(chunk));
+                        res.on('end', () => {
+                            try {
+                                const data = JSON.parse(Buffer.concat(chunks).toString());
+                                if (!data) {
+                                    reject(new FetchError('No data received', false));
+                                } else {
+                                    resolve({ data });
+                                }
+                            } catch (err) {
+                                reject(err);
+                            }
+                        });
+                    }
+                },
+            );
+            req.on('error', reject);
+            req.write(payload);
+            req.end();
+        });
+    }
+
+    private async webPost(config?: PostRequestConfig | undefined): Promise<FetchResult> {
+        const response = await fetch(this.endpoint, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                ...(config?.headers || {}),
+            },
+            body: JSON.stringify(config?.body ?? {}),
         });
 
         if (!response) {

--- a/tas-client/test/AssignmentsApiFeatureProvider.test.ts
+++ b/tas-client/test/AssignmentsApiFeatureProvider.test.ts
@@ -1,0 +1,313 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IExperimentationTelemetry } from '../src/contracts/IExperimentationTelemetry.js';
+import { IExperimentationFilterProvider } from '../src/contracts/IExperimentationFilterProvider.js';
+import {
+    AssignmentsApiFeatureProvider,
+    AssignmentRequest,
+    ASSIGNMENTS_FETCHERROR_EVENTNAME,
+    ASSIGNMENTS_VALIDATION_EVENTNAME,
+} from '../src/tas-client/FeatureProvider/AssignmentsApiFeatureProvider.js';
+import { FetchError, FetchResult, HttpClient } from '../src/tas-client/Util/HttpClient.js';
+import { It, Mock, Times } from 'typemoq';
+import { expect, describe, it } from 'vitest';
+
+class OneFilterProvider implements IExperimentationFilterProvider {
+    public getFilters(): Map<string, any> {
+        const filters = new Map<string, any>();
+        filters.set('X-VSCode-Build', 'insider');
+        filters.set('X-Empty', '');
+        filters.set('X-Null', null);
+        return filters;
+    }
+}
+
+describe('Assignments Api Feature Provider Tests', () => {
+    it('Should POST userParams built from non-empty filters.', async () => {
+        const httpClient = Mock.ofType<HttpClient>();
+        const telemetry = Mock.ofType<IExperimentationTelemetry>();
+        const fetchResponse = Mock.ofType<FetchResult>();
+        const responseData = {
+            featureVariables: { foo: 'bar' },
+            assignedVariants: [],
+            dataVersion: 3,
+            assignmentContext: 'ctx',
+        };
+
+        fetchResponse.setup((a: any) => a.then).returns(() => undefined);
+        fetchResponse.setup((a) => a.data).returns(() => responseData);
+
+        let capturedBody: AssignmentRequest | undefined;
+        httpClient
+            .setup((a) => a.post(It.isAny()))
+            .callback((cfg: any) => {
+                capturedBody = cfg?.body as AssignmentRequest;
+            })
+            .returns(() => Promise.resolve(fetchResponse.object))
+            .verifiable(Times.once());
+
+        const provider = new AssignmentsApiFeatureProvider(httpClient.object, telemetry.object, [
+            new OneFilterProvider(),
+        ]);
+        const result = await provider.fetch();
+
+        httpClient.verifyAll();
+        // Only the non-empty, non-null filter should be present.
+        expect(capturedBody).toEqual({ userParams: { 'X-VSCode-Build': 'insider' } });
+        // Response is mapped and merged into the active feature set.
+        expect(result).toEqual({
+            features: ['foo'],
+            assignmentContext: 'ctx',
+            configs: [{ Id: 'vscode', Parameters: { foo: 'bar' } }],
+        });
+    });
+
+    it('Should POST userParams using the filter keys verbatim.', async () => {
+        const httpClient = Mock.ofType<HttpClient>();
+        const telemetry = Mock.ofType<IExperimentationTelemetry>();
+        const fetchResponse = Mock.ofType<FetchResult>();
+        const responseData = {
+            featureVariables: {},
+            assignedVariants: [],
+            dataVersion: 1,
+            assignmentContext: '',
+        };
+
+        fetchResponse.setup((a: any) => a.then).returns(() => undefined);
+        fetchResponse.setup((a) => a.data).returns(() => responseData);
+
+        let capturedBody: AssignmentRequest | undefined;
+        httpClient
+            .setup((a) => a.post(It.isAny()))
+            .callback((cfg: any) => {
+                capturedBody = cfg?.body as AssignmentRequest;
+            })
+            .returns(() => Promise.resolve(fetchResponse.object));
+
+        const provider = new AssignmentsApiFeatureProvider(
+            httpClient.object,
+            telemetry.object,
+            [new OneFilterProvider()],
+        );
+        await provider.fetch();
+
+        // Assignments providers emit the final key names; empty/null values are dropped.
+        expect(capturedBody).toEqual({ userParams: { 'X-VSCode-Build': 'insider' } });
+    });
+
+    it('Should post validation telemetry on success.', async () => {
+        const httpClient = Mock.ofType<HttpClient>();
+        const telemetry = Mock.ofType<IExperimentationTelemetry>();
+        const fetchResponse = Mock.ofType<FetchResult>();
+        const responseData = {
+            featureVariables: { foo: 'bar', baz: 'qux' },
+            assignedVariants: [{ name: 'v1' }],
+            dataVersion: 7,
+            assignmentContext: 'ctx',
+        };
+
+        fetchResponse.setup((a: any) => a.then).returns(() => undefined);
+        fetchResponse.setup((a) => a.data).returns(() => responseData);
+        httpClient
+            .setup((a) => a.post(It.isAny()))
+            .returns(() => Promise.resolve(fetchResponse.object));
+
+        telemetry
+            .setup((t) =>
+                t.postEvent(
+                    It.isValue(ASSIGNMENTS_VALIDATION_EVENTNAME),
+                    It.is(
+                        (map) =>
+                            map.get('FeatureVariableCount') === '2' &&
+                            map.get('AssignedVariantCount') === '1' &&
+                            map.get('DataVersion') === '7' &&
+                            map.get('AssignmentContext') === 'ctx',
+                    ),
+                ),
+            )
+            .verifiable(Times.once());
+
+        const provider = new AssignmentsApiFeatureProvider(httpClient.object, telemetry.object, [
+            new OneFilterProvider(),
+        ]);
+        await provider.fetch();
+
+        telemetry.verifyAll();
+    });
+
+    it('Should NOT call the endpoint when there are no userParams.', async () => {
+        const httpClient = Mock.ofType<HttpClient>();
+        const telemetry = Mock.ofType<IExperimentationTelemetry>();
+
+        httpClient.setup((a) => a.post(It.isAny())).verifiable(Times.never());
+
+        const provider = new AssignmentsApiFeatureProvider(httpClient.object, telemetry.object, []);
+        const result = await provider.fetch();
+
+        httpClient.verifyAll();
+        expect(result).toEqual({ features: [], assignmentContext: '', configs: [] });
+    });
+
+    it('Should swallow errors, emit error telemetry and return empty data (shadow-safe).', async () => {
+        const httpClient = Mock.ofType<HttpClient>();
+        const telemetry = Mock.ofType<IExperimentationTelemetry>();
+        const fetchError = new FetchError('ServerError', true, false);
+
+        httpClient.setup((a) => a.post(It.isAny())).returns(() => Promise.reject(fetchError));
+
+        telemetry
+            .setup((t) =>
+                t.postEvent(
+                    It.isValue(ASSIGNMENTS_FETCHERROR_EVENTNAME),
+                    It.is((map) => map.get('ErrorType') === 'ServerError'),
+                ),
+            )
+            .verifiable(Times.once());
+
+        const provider = new AssignmentsApiFeatureProvider(httpClient.object, telemetry.object, [
+            new OneFilterProvider(),
+        ]);
+
+        // Must never throw.
+        const result = await provider.fetch();
+
+        telemetry.verifyAll();
+        expect(result).toEqual({ features: [], assignmentContext: '', configs: [] });
+    });
+
+    it('Should map featureVariables into a vscode config with coerced values and no cf suffix.', async () => {
+        const httpClient = Mock.ofType<HttpClient>();
+        const telemetry = Mock.ofType<IExperimentationTelemetry>();
+        const fetchResponse = Mock.ofType<FetchResult>();
+        const responseData = {
+            featureVariables: {
+                boolTrue: 'true',
+                boolFalse: 'false',
+                num: '42',
+                str: 'treatment',
+            },
+            assignedVariants: [],
+            dataVersion: 5,
+            assignmentContext: 'ctx',
+        };
+
+        fetchResponse.setup((a: any) => a.then).returns(() => undefined);
+        fetchResponse.setup((a) => a.data).returns(() => responseData);
+        httpClient
+            .setup((a) => a.post(It.isAny()))
+            .returns(() => Promise.resolve(fetchResponse.object));
+
+        const provider = new AssignmentsApiFeatureProvider(httpClient.object, telemetry.object, [
+            new OneFilterProvider(),
+        ]);
+        const result = await provider.fetch();
+
+        expect(result.assignmentContext).toBe('ctx');
+        // Strings are coerced to booleans/numbers so lookups match the legacy provider's types.
+        expect(result.configs).toEqual([
+            {
+                Id: 'vscode',
+                Parameters: { boolTrue: true, boolFalse: false, num: 42, str: 'treatment' },
+            },
+        ]);
+        // No 'cf' suffix; only truthy-valued variables are listed as enabled flights.
+        expect(result.features).toEqual(['boolTrue', 'num', 'str']);
+    });
+
+    it('Should keep configs even when every variable is falsy.', async () => {
+        const httpClient = Mock.ofType<HttpClient>();
+        const telemetry = Mock.ofType<IExperimentationTelemetry>();
+        const fetchResponse = Mock.ofType<FetchResult>();
+        const responseData = {
+            featureVariables: { flag: 'false' },
+            assignedVariants: [],
+            dataVersion: 1,
+            assignmentContext: '',
+        };
+
+        fetchResponse.setup((a: any) => a.then).returns(() => undefined);
+        fetchResponse.setup((a) => a.data).returns(() => responseData);
+        httpClient
+            .setup((a) => a.post(It.isAny()))
+            .returns(() => Promise.resolve(fetchResponse.object));
+
+        const provider = new AssignmentsApiFeatureProvider(httpClient.object, telemetry.object, [
+            new OneFilterProvider(),
+        ]);
+        const result = await provider.fetch();
+
+        expect(result.features).toEqual([]);
+        expect(result.configs).toEqual([{ Id: 'vscode', Parameters: { flag: false } }]);
+    });
+
+    it('Should use the provided fetchFn transport instead of the HTTP client.', async () => {
+        const httpClient = Mock.ofType<HttpClient>();
+        const telemetry = Mock.ofType<IExperimentationTelemetry>();
+        const responseData = {
+            featureVariables: { foo: 'bar' },
+            assignedVariants: [],
+            dataVersion: 1,
+            assignmentContext: 'ctx',
+        };
+
+        let calledUrl: string | undefined;
+        let calledInit: { method: string; headers: Record<string, string>; body: string } | undefined;
+        const fetchFn = async (
+            url: string,
+            init: { method: 'POST'; headers: Record<string, string>; body: string },
+        ) => {
+            calledUrl = url;
+            calledInit = init;
+            return { status: 200, json: async () => responseData };
+        };
+
+        httpClient.setup((a) => a.post(It.isAny())).verifiable(Times.never());
+
+        const provider = new AssignmentsApiFeatureProvider(
+            httpClient.object,
+            telemetry.object,
+            [new OneFilterProvider()],
+            'https://example.test/api/v1/assignments',
+            fetchFn,
+        );
+        const result = await provider.fetch();
+
+        httpClient.verifyAll(); // built-in POST must not be used
+        expect(calledUrl).toBe('https://example.test/api/v1/assignments');
+        expect(calledInit?.method).toBe('POST');
+        expect(JSON.parse(calledInit!.body)).toEqual({
+            userParams: { 'X-VSCode-Build': 'insider' },
+        });
+        expect(result.configs).toEqual([{ Id: 'vscode', Parameters: { foo: 'bar' } }]);
+    });
+
+    it('Should return empty data and post error telemetry when fetchFn returns non-2xx.', async () => {
+        const httpClient = Mock.ofType<HttpClient>();
+        const telemetry = Mock.ofType<IExperimentationTelemetry>();
+        const fetchFn = async () => ({ status: 500, json: async () => ({}) });
+
+        telemetry
+            .setup((t) =>
+                t.postEvent(
+                    It.isValue(ASSIGNMENTS_FETCHERROR_EVENTNAME),
+                    It.is((map) => map.get('ErrorType') === 'ServerError'),
+                ),
+            )
+            .verifiable(Times.once());
+
+        const provider = new AssignmentsApiFeatureProvider(
+            httpClient.object,
+            telemetry.object,
+            [new OneFilterProvider()],
+            'https://example.test',
+            fetchFn,
+        );
+        const result = await provider.fetch();
+
+        telemetry.verifyAll();
+        expect(result).toEqual({ features: [], assignmentContext: '', configs: [] });
+    });
+});

--- a/tas-client/test/HttpClient.test.ts
+++ b/tas-client/test/HttpClient.test.ts
@@ -79,4 +79,26 @@ describe('HttpClient Tests', () => {
         expect(result.data.headers['echo-header']).toBe('echo-http');
         expect(result.data.headers['user-agent']).toBe(undefined); // only set with fetch
     });
+
+    it('should POST a JSON body using fetch', async () => {
+        const path = '/api/v1/assignments';
+        const client = new HttpClient(`http://127.0.0.1:${port}${path}`, false);
+        const body = { userParams: { 'X-VSCode-Build': 'insider' } };
+        const result = await client.post({ body });
+        expect(result.data.method).toBe('POST');
+        expect(result.data.url).toBe(path);
+        expect(result.data.headers['content-type']).toBe('application/json');
+        expect(JSON.parse(result.data.data)).toEqual(body);
+    });
+
+    it('should POST a JSON body using Node.js modules', async () => {
+        const path = '/api/v1/assignments';
+        const client = new HttpClient(`http://127.0.0.1:${port}${path}`, true);
+        const body = { userParams: { 'X-VSCode-Build': 'insider' } };
+        const result = await client.post({ body });
+        expect(result.data.method).toBe('POST');
+        expect(result.data.url).toBe(path);
+        expect(result.data.headers['content-type']).toBe('application/json');
+        expect(JSON.parse(result.data.data)).toEqual(body);
+    });
 });


### PR DESCRIPTION
### Summary
Adds support for the new TAS assignments API (POST /api/v1/assignments) alongside the existing endpoint, so experiment assignments can be sourced from both during the migration window. The new endpoint is opt-in via the assignmentsEndpoint config option. When set, its assignments are merged into the active feature set with new values taking precedence for overlapping variables; on failure it contributes nothing so the legacy endpoint's results are preserved.
This is the library-only change. `vscode-tas-client` will be updated separately once this is published.

### What's included

- New AssignmentsApiFeatureProvider — calls the assignments API via POST, builds userParams from its own filter providers, and maps the response (featureVariables, assignmentContext) into the internal FeatureData shape (with string→bool/number coercion). It never throws — on any failure it returns empty data and posts error telemetry, so it can't wipe out the primary provider's results.
- HttpClient.post() — JSON POST support for both the Node (http/https) and web (fetch) transports, mirroring the existing get() error handling.
- New config options on ExperimentationServiceConfig:
- assignmentsEndpoint? — enables the new provider when set.
- assignmentsFilterProviders? — filter providers dedicated to the new endpoint, emitting the new parameter names so legacy header keys never reach it (falls back to the legacy providers if omitted).
- assignmentsFetch? — optional custom transport (AssignmentsFetchFn) so hosts can route the request through their own networking stack.
- assignmentContext merge fix — contexts from multiple providers are now joined with ; so downstream consumers that split on ; don't merge two providers' segments into one token.
- Tests — coverage for the new provider (POST body, response mapping/coercion, fetchFn transport, non-2xx and error isolation) and HttpClient.post() across both transports.

### Behavior / compatibility

- No behavior change unless assignmentsEndpoint is set — existing consumers are unaffected.
- Package remains pure ESM (type: module, ESM bundle) — no change to module format.
- Version bumped 0.4.1 → 0.4.2; package-lock.json synced.

**Testing**
npm run compile, npm run bundle (ESM), and npx vitest run — all green (45 tests).