### PR TITLE
Fix legacy TAS proxy transport; add unified fetch hook

### DIFF
--- a/tas-client/README.md
+++ b/tas-client/README.md
@@ -38,5 +38,36 @@ Once you have an instance of `IExperimentationService` you can call `getTreatmen
 
 > NOTE: If you haven't awaited the `IExperimentationService`'s `initializePromise`, you need to use `getTreatmentVariableAsync`.
 
+### 0.4.3
 
 
+## Custom transport (`fetch`)
+
+By default the client issues requests with its built-in HTTP client. To route requests through your own networking stack (for example to add proxy support, retries, or a custom user-agent), provide a `fetch` function in the config. It is used for both the legacy `endpoint` (GET) and the optional `assignmentsEndpoint` (POST):
+
+```javascript
+const tasClient = new TASClient({
+    // ...existing options...
+    endpoint: '<tas-endpoint>',
+    assignmentsEndpoint: '<assignments-endpoint>', // optional
+    extensionName: '<caller-name>',                // optional; attached to `tas-call` telemetry
+    fetch: async (url, init) => {
+        // init.method is 'GET' (legacy) or 'POST' (assignments); init.body is set for POST.
+        const res = await myHttp(url, { method: init.method, headers: init.headers, body: init.body });
+        return { status: res.status, json: () => res.json() };
+    },
+});
+```
+
+A per-endpoint `assignmentsFetch` still overrides `fetch` for the assignments request. The deprecated `AssignmentsFetchFn` / `IAssignmentsFetchResponse` types remain as aliases of `FetchFn` / `IFetchResponse`.
+
+## Telemetry: `tas-call`
+
+Each TAS call emits a uniform `tas-call` event so callers can confirm calls are being made and are succeeding:
+
+| Property | Description |
+| --- | --- |
+| `callType` | `legacy` or `assignments` |
+| `outcome` | `Success`, `ServerError`, `NoResponse`, or `GenericError` |
+| `extensionName` | The caller name provided via config |
+| `assignmentContext` | The assignment context returned by that call |

--- a/tas-client/package-lock.json
+++ b/tas-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tas-client",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tas-client",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.19.15",

--- a/tas-client/package.json
+++ b/tas-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tas-client",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/tas-client/src/contracts/ExperimentationServiceConfig.ts
+++ b/tas-client/src/contracts/ExperimentationServiceConfig.ts
@@ -8,23 +8,37 @@ import { IExperimentationFilterProvider } from './IExperimentationFilterProvider
 import { IKeyValueStorage } from './IKeyValueStorage.js';
 
 /**
- * Minimal response shape returned by {@link AssignmentsFetchFn}, matching the subset of the
- * Fetch API the assignments provider needs.
+ * Minimal response shape returned by {@link FetchFn}, matching the subset of the
+ * Fetch API the providers need.
  */
-export interface IAssignmentsFetchResponse {
+export interface IFetchResponse {
     readonly status: number;
     json(): Promise<any>;
 }
 
+/** @deprecated Use {@link IFetchResponse}. */
+export type IAssignmentsFetchResponse = IFetchResponse;
+
 /**
- * Optional custom transport for the new TAS assignments API. When provided, the assignments
- * provider uses this instead of its built-in HTTP client, so hosts can route the request
- * through their own networking stack (proxy handling, retries, user-agent, etc.).
+ * Optional custom transport used for both the legacy endpoint (GET) and the assignments
+ * endpoint (POST). When provided via {@link ExperimentationServiceConfig.fetch}, providers
+ * use this instead of their built-in HTTP client, so hosts can route requests through their
+ * own networking stack (proxy handling, retries, user-agent, etc.). Filters are passed as
+ * request headers (legacy) and the assignments body is passed as a JSON string.
+ */
+export type FetchFn = (
+    url: string,
+    init: { method: 'GET' | 'POST'; headers: Record<string, string>; body?: string },
+) => Promise<IFetchResponse>;
+
+/**
+ * @deprecated Use {@link FetchFn} via {@link ExperimentationServiceConfig.fetch}, which is
+ * used for both the legacy and assignments endpoints. Retained for backward compatibility.
  */
 export type AssignmentsFetchFn = (
     url: string,
     init: { method: 'POST'; headers: Record<string, string>; body: string },
-) => Promise<IAssignmentsFetchResponse>;
+) => Promise<IFetchResponse>;
 
 /**
  * Options that include the implementations of the Experimentation service.
@@ -32,6 +46,19 @@ export type AssignmentsFetchFn = (
 export interface ExperimentationServiceConfig {
     telemetry: IExperimentationTelemetry;
     endpoint: string;
+    /**
+     * Optional friendly name of the calling extension/host, emitted on the `tas-call`
+     * telemetry event so each TAS call can be attributed to its caller.
+     */
+    extensionName?: string;
+    /**
+     * Optional custom transport used for both the legacy {@link endpoint} (GET) and the
+     * {@link assignmentsEndpoint} (POST). When provided, it is used instead of the built-in
+     * HTTP client, letting hosts route requests through their own networking stack (e.g. the
+     * VS Code fetcher service) for proxy support. A per-endpoint {@link assignmentsFetch}, if
+     * set, takes precedence for the assignments request.
+     */
+    fetch?: FetchFn;
     /**
      * Optional endpoint for the new TAS assignments API (POST /api/v1/assignments).
      * When set, a request is sent to this endpoint in parallel with the main endpoint and

--- a/tas-client/src/index.ts
+++ b/tas-client/src/index.ts
@@ -8,4 +8,4 @@ export { IExperimentationService } from './contracts/IExperimentationService.js'
 export { IExperimentationTelemetry } from './contracts/IExperimentationTelemetry.js';
 export { IKeyValueStorage } from './contracts/IKeyValueStorage.js';
 export { ExperimentationService } from './tas-client/ExperimentationService.js';
-export { ExperimentationServiceConfig, AssignmentsFetchFn, IAssignmentsFetchResponse } from './contracts/ExperimentationServiceConfig.js';
+export { ExperimentationServiceConfig, FetchFn, AssignmentsFetchFn, IFetchResponse, IAssignmentsFetchResponse } from './contracts/ExperimentationServiceConfig.js';

--- a/tas-client/src/tas-client/ExperimentationService.ts
+++ b/tas-client/src/tas-client/ExperimentationService.ts
@@ -45,6 +45,9 @@ export class ExperimentationService extends ExperimentationServiceAutoPolling {
                 new HttpClient(this.options.endpoint),
                 this.telemetry,
                 this.filterProviders,
+                this.options.endpoint,
+                this.options.fetch,
+                this.options.extensionName,
             ),
         );
 
@@ -60,7 +63,8 @@ export class ExperimentationService extends ExperimentationServiceAutoPolling {
                     this.telemetry,
                     this.options.assignmentsFilterProviders ?? this.filterProviders,
                     this.options.assignmentsEndpoint,
-                    this.options.assignmentsFetch,
+                    this.options.assignmentsFetch ?? this.options.fetch,
+                    this.options.extensionName,
                 ),
             );
         }

--- a/tas-client/src/tas-client/ExperimentationServiceBase.ts
+++ b/tas-client/src/tas-client/ExperimentationServiceBase.ts
@@ -17,7 +17,7 @@ import { MemoryKeyValueStorage } from './Util/MemoryKeyValueStorage.js';
  */
 export abstract class ExperimentationServiceBase implements IExperimentationService {
     protected featureProviders?: IFeatureProvider[];
-    protected fetchPromise?: Promise<FeatureData[]>;
+    protected fetchPromise?: Promise<(FeatureData | undefined)[]>;
     protected featuresConsumed = false;
     private loadCachePromise: Promise<void>;
     public readonly initializePromise: Promise<void>;
@@ -93,15 +93,28 @@ export abstract class ExperimentationServiceBase implements IExperimentationServ
 
         try {
             /**
-             * Fetch all from providers.
+             * Fetch all from providers. Provider failures are isolated so that one provider
+             * (e.g. the legacy TAS endpoint) rejecting cannot discard the results of the
+             * others (e.g. the new assignments endpoint). A provider that fails contributes
+             * `undefined` and is skipped during the merge.
              */
             this.fetchPromise = Promise.all(
-                this.featureProviders.map(async (provider) => {
-                    return await provider.getFeatures();
-                }),
+                this.featureProviders.map((provider) =>
+                    provider.getFeatures().then(
+                        (data) => data,
+                        () => undefined,
+                    ),
+                ),
             );
             const featureResults = await this.fetchPromise;
-            this.updateFeatures(featureResults, overrideInMemoryFeatures);
+            const successfulResults = featureResults.filter(
+                (result): result is FeatureData => result !== undefined,
+            );
+            // Only update when at least one provider succeeded, so a total failure keeps
+            // the previously cached features instead of clobbering them with empty data.
+            if (successfulResults.length > 0) {
+                this.updateFeatures(successfulResults, overrideInMemoryFeatures);
+            }
         } catch {
             // Fetching features threw error. Can happen if not connected to the internet, e.g.
         }

--- a/tas-client/src/tas-client/FeatureProvider/AssignmentsApiFeatureProvider.ts
+++ b/tas-client/src/tas-client/FeatureProvider/AssignmentsApiFeatureProvider.ts
@@ -12,6 +12,7 @@ import { FeatureData } from './IFeatureProvider.js';
 
 export const ASSIGNMENTS_FETCHERROR_EVENTNAME = 'call-assignments-error';
 export const ASSIGNMENTS_VALIDATION_EVENTNAME = 'assignments-validation';
+export const TAS_CALL_EVENTNAME = 'tas-call';
 const ERROR_TYPE = 'ErrorType';
 
 /**
@@ -36,6 +37,7 @@ export class AssignmentsApiFeatureProvider extends FilteredFeatureProvider {
         protected filterProviders: IExperimentationFilterProvider[],
         protected endpoint?: string,
         protected fetchFn?: AssignmentsFetchFn,
+        protected extensionName?: string,
     ) {
         super(telemetry, filterProviders);
     }
@@ -100,6 +102,8 @@ export class AssignmentsApiFeatureProvider extends FilteredFeatureProvider {
         } catch {
             // Validation telemetry must never affect feature assignment.
         }
+
+        this.postCallTelemetry('Success', responseData.assignmentContext || '');
 
         // Merge the new endpoint's assignments into the active feature set.
         return AssignmentsApiFeatureProvider.toFeatureData(responseData);
@@ -174,14 +178,27 @@ export class AssignmentsApiFeatureProvider extends FilteredFeatureProvider {
 
     private postErrorTelemetry(fetchError: FetchError): void {
         const properties: Map<string, string> = new Map();
+        let outcome: string;
         if (fetchError.responseReceived && !fetchError.responseOk) {
-            properties.set(ERROR_TYPE, 'ServerError');
+            outcome = 'ServerError';
         } else if (fetchError.responseReceived === false) {
-            properties.set(ERROR_TYPE, 'NoResponse');
+            outcome = 'NoResponse';
         } else {
-            properties.set(ERROR_TYPE, 'GenericError');
+            outcome = 'GenericError';
         }
+        properties.set(ERROR_TYPE, outcome);
         this.telemetry.postEvent(ASSIGNMENTS_FETCHERROR_EVENTNAME, properties);
+        this.postCallTelemetry(outcome);
+    }
+
+    /** Emits a uniform per-call event so callers can confirm a new-TAS call and its outcome. */
+    private postCallTelemetry(outcome: string, assignmentContext: string = ''): void {
+        const properties: Map<string, string> = new Map();
+        properties.set('callType', 'assignments');
+        properties.set('outcome', outcome);
+        properties.set('extensionName', this.extensionName ?? '');
+        properties.set('assignmentContext', assignmentContext);
+        this.telemetry.postEvent(TAS_CALL_EVENTNAME, properties);
     }
 }
 

--- a/tas-client/src/tas-client/FeatureProvider/AssignmentsApiFeatureProvider.ts
+++ b/tas-client/src/tas-client/FeatureProvider/AssignmentsApiFeatureProvider.ts
@@ -21,9 +21,10 @@ const ERROR_TYPE = 'ErrorType';
  *
  * Its parsed assignments are merged with the legacy provider's results by the base
  * service: because this provider is registered after the legacy one, variables from the
- * new endpoint override/augment the legacy ones for the same config. On any failure it
- * resolves with empty feature data and never throws, so a problem with the new endpoint
- * cannot wipe out the legacy (authoritative) provider's results.
+ * new endpoint override/augment the legacy ones for the same config. On failure it rejects;
+ * the base service isolates per-provider failures, so a failed new-endpoint call neither
+ * wipes out the legacy (authoritative) provider's results nor is treated as a successful
+ * empty result that could overwrite cached features.
  */
 export class AssignmentsApiFeatureProvider extends FilteredFeatureProvider {
     /**
@@ -50,8 +51,9 @@ export class AssignmentsApiFeatureProvider extends FilteredFeatureProvider {
 
     /**
      * Calls the new assignments API and returns its assignments as feature data to be
-     * merged with the legacy provider. Never throws; on any failure it returns empty
-     * feature data so the legacy provider's results are preserved.
+     * merged with the legacy provider. Returns empty feature data when there are no user
+     * params to send (a valid no-op); rejects on any transport, parse, or conversion
+     * failure so the base service excludes it from the merge.
      */
     public async fetch(): Promise<FeatureData> {
         const userParams = this.buildUserParams();
@@ -63,8 +65,8 @@ export class AssignmentsApiFeatureProvider extends FilteredFeatureProvider {
 
         const requestBody: AssignmentRequest = { userParams };
 
-        let responseData: AssignmentResponse;
         try {
+            let responseData: AssignmentResponse;
             if (this.fetchFn) {
                 // Host-provided transport (e.g. VS Code fetcher service).
                 const res = await this.fetchFn(this.endpoint!, {
@@ -73,40 +75,50 @@ export class AssignmentsApiFeatureProvider extends FilteredFeatureProvider {
                     body: JSON.stringify(requestBody),
                 });
                 if (res.status < 200 || res.status > 299) {
-                    this.postErrorTelemetry(new FetchError('Response not ok', true, false));
-                    return AssignmentsApiFeatureProvider.EMPTY_FEATURE_DATA;
+                    throw new FetchError('Response not ok', true, false);
                 }
                 responseData = (await res.json()) as AssignmentResponse;
             } else {
                 const response: FetchResult = await this.httpClient.post({ body: requestBody });
                 responseData = response.data as AssignmentResponse;
             }
+
+            if (!responseData) {
+                throw new FetchError('No data received', false);
+            }
+
+            // Convert inside the guarded path so a malformed response is treated as a
+            // failure (rejects) rather than being reported as a successful empty result.
+            const featureData = AssignmentsApiFeatureProvider.toFeatureData(responseData);
+
+            try {
+                const properties: Map<string, string> = new Map();
+                properties.set(
+                    'FeatureVariableCount',
+                    String(Object.keys(responseData.featureVariables || {}).length),
+                );
+                properties.set(
+                    'AssignedVariantCount',
+                    String((responseData.assignedVariants || []).length),
+                );
+                properties.set('DataVersion', String(responseData.dataVersion));
+                properties.set('AssignmentContext', responseData.assignmentContext || '');
+                this.telemetry.postEvent(ASSIGNMENTS_VALIDATION_EVENTNAME, properties);
+            } catch {
+                // Validation telemetry must never affect feature assignment.
+            }
+
+            // Report success only after the response has been converted.
+            this.postCallTelemetry('Success', responseData.assignmentContext || '');
+
+            return featureData;
         } catch (error) {
             this.postErrorTelemetry(error as FetchError);
-            return AssignmentsApiFeatureProvider.EMPTY_FEATURE_DATA;
+            // Reject so the service's fault-isolation excludes this provider. A failed
+            // assignments call must not be treated as an empty-but-successful result that
+            // could overwrite cached features when the legacy provider also fails.
+            throw error;
         }
-
-        try {
-            const properties: Map<string, string> = new Map();
-            properties.set(
-                'FeatureVariableCount',
-                String(Object.keys(responseData.featureVariables || {}).length),
-            );
-            properties.set(
-                'AssignedVariantCount',
-                String((responseData.assignedVariants || []).length),
-            );
-            properties.set('DataVersion', String(responseData.dataVersion));
-            properties.set('AssignmentContext', responseData.assignmentContext || '');
-            this.telemetry.postEvent(ASSIGNMENTS_VALIDATION_EVENTNAME, properties);
-        } catch {
-            // Validation telemetry must never affect feature assignment.
-        }
-
-        this.postCallTelemetry('Success', responseData.assignmentContext || '');
-
-        // Merge the new endpoint's assignments into the active feature set.
-        return AssignmentsApiFeatureProvider.toFeatureData(responseData);
     }
 
     /**

--- a/tas-client/src/tas-client/FeatureProvider/BaseFeatureProvider.ts
+++ b/tas-client/src/tas-client/FeatureProvider/BaseFeatureProvider.ts
@@ -16,7 +16,7 @@ export abstract class BaseFeatureProvider implements IFeatureProvider {
     /**
      * @param telemetry The telemetry implementation.
      */
-    constructor(protected telemetry: IExperimentationTelemetry) {}
+    constructor(protected telemetry: IExperimentationTelemetry) { }
 
     /**
      * Method that wraps the fetch method in order to re-use the fetch promise if needed.
@@ -27,12 +27,15 @@ export abstract class BaseFeatureProvider implements IFeatureProvider {
             return this.fetchPromise;
         }
 
+        this.isFetching = true;
         this.fetchPromise = this.fetch();
-        let features = await this.fetchPromise;
-        this.isFetching = false;
-        this.fetchPromise = undefined;
-
-        return features;
+        try {
+            return await this.fetchPromise;
+        } finally {
+            // Reset even if the fetch rejected, so a failed cycle doesn't wedge future fetches.
+            this.isFetching = false;
+            this.fetchPromise = undefined;
+        }
     }
 
     /**

--- a/tas-client/src/tas-client/FeatureProvider/TasApiFeatureProvider.ts
+++ b/tas-client/src/tas-client/FeatureProvider/TasApiFeatureProvider.ts
@@ -6,10 +6,12 @@
 import { IExperimentationFilterProvider } from '../../contracts/IExperimentationFilterProvider.js';
 import { FetchError, FetchResult, HttpClient } from '../Util/HttpClient.js';
 import { IExperimentationTelemetry } from '../../contracts/IExperimentationTelemetry.js';
+import { FetchFn } from '../../contracts/ExperimentationServiceConfig.js';
 import { FilteredFeatureProvider } from './FilteredFeatureProvider.js';
 import { FeatureData, ConfigData } from './IFeatureProvider.js';
 
 export const TASAPI_FETCHERROR_EVENTNAME = 'call-tas-error';
+export const TAS_CALL_EVENTNAME = 'tas-call';
 const ERROR_TYPE = 'ErrorType';
 /**
  * Feature provider implementation that calls the TAS web service to get the most recent active features.
@@ -19,8 +21,21 @@ export class TasApiFeatureProvider extends FilteredFeatureProvider {
         protected httpClient: HttpClient,
         protected telemetry: IExperimentationTelemetry,
         protected filterProviders: IExperimentationFilterProvider[],
+        protected endpoint?: string,
+        protected fetchFn?: FetchFn,
+        protected extensionName?: string,
     ) {
         super(telemetry, filterProviders);
+    }
+
+    /** Emits a uniform per-call event so callers can confirm a legacy TAS call and its outcome. */
+    private postCallTelemetry(outcome: string, assignmentContext: string = ''): void {
+        const properties: Map<string, string> = new Map();
+        properties.set('callType', 'legacy');
+        properties.set('outcome', outcome);
+        properties.set('extensionName', this.extensionName ?? '');
+        properties.set('assignmentContext', assignmentContext);
+        this.telemetry.postEvent(TAS_CALL_EVENTNAME, properties);
     }
 
     /**
@@ -42,7 +57,16 @@ export class TasApiFeatureProvider extends FilteredFeatureProvider {
         let response: FetchResult | undefined;
 
         try {
-            response = await this.httpClient.get({ headers: headers });
+            if (this.fetchFn && this.endpoint) {
+                // Host-provided transport (e.g. VS Code fetcher service) for proxy support.
+                const res = await this.fetchFn(this.endpoint, { method: 'GET', headers });
+                if (res.status < 200 || res.status > 299) {
+                    throw new FetchError('Response not ok', true, false);
+                }
+                response = { data: await res.json() };
+            } else {
+                response = await this.httpClient.get({ headers: headers });
+            }
         } catch (error) {
             const fetchError = error as FetchError;
             const properties: Map<string, string> = new Map();
@@ -58,6 +82,7 @@ export class TasApiFeatureProvider extends FilteredFeatureProvider {
                 properties.set(ERROR_TYPE, 'GenericError');
             }
             this.telemetry.postEvent(TASAPI_FETCHERROR_EVENTNAME, properties);
+            this.postCallTelemetry(properties.get(ERROR_TYPE)!);
         }
 
         // In case the response fetching failed, throw
@@ -65,6 +90,8 @@ export class TasApiFeatureProvider extends FilteredFeatureProvider {
         if (!response) {
             throw Error(TASAPI_FETCHERROR_EVENTNAME);
         }
+
+        this.postCallTelemetry('Success', response.data?.AssignmentContext ?? '');
 
         // If we have at least one filter, we post it to telemetry event.
         if (filters.keys.length > 0) {

--- a/tas-client/src/tas-client/FeatureProvider/TasApiFeatureProvider.ts
+++ b/tas-client/src/tas-client/FeatureProvider/TasApiFeatureProvider.ts
@@ -54,9 +54,8 @@ export class TasApiFeatureProvider extends FilteredFeatureProvider {
         }
 
         //webservice call
-        let response: FetchResult | undefined;
-
         try {
+            let response: FetchResult | undefined;
             if (this.fetchFn && this.endpoint) {
                 // Host-provided transport (e.g. VS Code fetcher service) for proxy support.
                 const res = await this.fetchFn(this.endpoint, { method: 'GET', headers });
@@ -67,6 +66,41 @@ export class TasApiFeatureProvider extends FilteredFeatureProvider {
             } else {
                 response = await this.httpClient.get({ headers: headers });
             }
+
+            if (!response || !response.data) {
+                throw new FetchError('No data received', false);
+            }
+
+            // Convert inside the guarded path so a malformed response (e.g. missing Configs)
+            // is classified as a failure rather than reported as a successful call.
+            const responseData = response.data;
+            const configs = responseData.Configs;
+            const features: string[] = [];
+            for (const c of configs) {
+                if (!c.Parameters) {
+                    continue;
+                }
+                for (const key of Object.keys(c.Parameters)) {
+                    const featureName = key + (c.Parameters[key] ? '' : 'cf');
+                    if (!features.includes(featureName)) {
+                        features.push(featureName);
+                    }
+                }
+            }
+
+            // Report success only after the response has been converted.
+            this.postCallTelemetry('Success', responseData.AssignmentContext ?? '');
+
+            // If we have at least one filter, we post it to telemetry event.
+            if (filters.keys.length > 0) {
+                this.PostEventToTelemetry(headers);
+            }
+
+            return {
+                features,
+                assignmentContext: responseData.AssignmentContext,
+                configs,
+            };
         } catch (error) {
             const fetchError = error as FetchError;
             const properties: Map<string, string> = new Map();
@@ -78,48 +112,13 @@ export class TasApiFeatureProvider extends FilteredFeatureProvider {
                 // The request was made but no response was received
                 properties.set(ERROR_TYPE, 'NoResponse');
             } else {
-                // Something happened in setting up the request that triggered an Error
+                // Something happened setting up the request or converting the response.
                 properties.set(ERROR_TYPE, 'GenericError');
             }
             this.telemetry.postEvent(TASAPI_FETCHERROR_EVENTNAME, properties);
             this.postCallTelemetry(properties.get(ERROR_TYPE)!);
-        }
-
-        // In case the response fetching failed, throw
-        // exception so that the caller exits.
-        if (!response) {
             throw Error(TASAPI_FETCHERROR_EVENTNAME);
         }
-
-        this.postCallTelemetry('Success', response.data?.AssignmentContext ?? '');
-
-        // If we have at least one filter, we post it to telemetry event.
-        if (filters.keys.length > 0) {
-            this.PostEventToTelemetry(headers);
-        }
-
-        // Read the response data from the server.
-        const responseData = response.data;
-        let configs = responseData.Configs;
-        let features: string[] = [];
-        for (let c of configs) {
-            if (!c.Parameters) {
-                continue;
-            }
-
-            for (let key of Object.keys(c.Parameters)) {
-                const featureName = key + (c.Parameters[key] ? '' : 'cf');
-                if (!features.includes(featureName)) {
-                    features.push(featureName);
-                }
-            }
-        }
-
-        return {
-            features,
-            assignmentContext: responseData.AssignmentContext,
-            configs,
-        };
     }
 }
 

--- a/tas-client/test/AssignmentsApiFeatureProvider.test.ts
+++ b/tas-client/test/AssignmentsApiFeatureProvider.test.ts
@@ -257,10 +257,10 @@ describe('Assignments Api Feature Provider Tests', () => {
         let calledInit: { method: string; headers: Record<string, string>; body: string } | undefined;
         const fetchFn = async (
             url: string,
-            init: { method: 'POST'; headers: Record<string, string>; body: string },
+            init: { method: 'GET' | 'POST'; headers: Record<string, string>; body?: string },
         ) => {
             calledUrl = url;
-            calledInit = init;
+            calledInit = init as typeof calledInit;
             return { status: 200, json: async () => responseData };
         };
 

--- a/tas-client/test/AssignmentsApiFeatureProvider.test.ts
+++ b/tas-client/test/AssignmentsApiFeatureProvider.test.ts
@@ -151,7 +151,7 @@ describe('Assignments Api Feature Provider Tests', () => {
         expect(result).toEqual({ features: [], assignmentContext: '', configs: [] });
     });
 
-    it('Should swallow errors, emit error telemetry and return empty data (shadow-safe).', async () => {
+    it('Should emit error telemetry and reject when the request fails.', async () => {
         const httpClient = Mock.ofType<HttpClient>();
         const telemetry = Mock.ofType<IExperimentationTelemetry>();
         const fetchError = new FetchError('ServerError', true, false);
@@ -171,11 +171,10 @@ describe('Assignments Api Feature Provider Tests', () => {
             new OneFilterProvider(),
         ]);
 
-        // Must never throw.
-        const result = await provider.fetch();
+        // Rejects so the base service's fault-isolation excludes this provider.
+        await expect(provider.fetch()).rejects.toBeDefined();
 
         telemetry.verifyAll();
-        expect(result).toEqual({ features: [], assignmentContext: '', configs: [] });
     });
 
     it('Should map featureVariables into a vscode config with coerced values and no cf suffix.', async () => {
@@ -284,7 +283,7 @@ describe('Assignments Api Feature Provider Tests', () => {
         expect(result.configs).toEqual([{ Id: 'vscode', Parameters: { foo: 'bar' } }]);
     });
 
-    it('Should return empty data and post error telemetry when fetchFn returns non-2xx.', async () => {
+    it('Should post error telemetry and reject when fetchFn returns non-2xx.', async () => {
         const httpClient = Mock.ofType<HttpClient>();
         const telemetry = Mock.ofType<IExperimentationTelemetry>();
         const fetchFn = async () => ({ status: 500, json: async () => ({}) });
@@ -305,9 +304,9 @@ describe('Assignments Api Feature Provider Tests', () => {
             'https://example.test',
             fetchFn,
         );
-        const result = await provider.fetch();
+
+        await expect(provider.fetch()).rejects.toBeDefined();
 
         telemetry.verifyAll();
-        expect(result).toEqual({ features: [], assignmentContext: '', configs: [] });
     });
 });

--- a/tas-client/test/Regression.test.ts
+++ b/tas-client/test/Regression.test.ts
@@ -1,0 +1,139 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { expect, describe, it } from 'vitest';
+import { ExperimentationServiceMock } from './mocks/ExperimentationServiceMock.js';
+import { BaseFeatureProviderMock, ThrowFeatureProvider } from './mocks/BaseFeatureProviderMock.js';
+import { ExperimentationTelemetryMock } from './mocks/ExperimentationTelemetryMock.js';
+import { KeyValueStorageMock } from './mocks/KeyValueStorageMock.js';
+import { FetchResolver } from './mocks/FetchResolver.js';
+import { TasApiFeatureProvider, TAS_CALL_EVENTNAME } from '../src/tas-client/FeatureProvider/TasApiFeatureProvider.js';
+import { AssignmentsApiFeatureProvider } from '../src/tas-client/FeatureProvider/AssignmentsApiFeatureProvider.js';
+import { ExperimentationFilterProviderOneFilterMock } from './mocks/ExperimentationFilterProviderMock.js';
+import { HttpClient } from '../src/tas-client/Util/HttpClient.js';
+
+// Regression: a failing feature provider (e.g. the legacy endpoint erroring) must not
+// discard the results of the other providers (e.g. the new assignments endpoint). This
+// guards the `Promise.all` -> fault-isolation fix in ExperimentationServiceBase.
+describe('Regression: provider fault isolation', () => {
+	it('a failing provider does not discard the other providers results', async () => {
+		const telemetry = new ExperimentationTelemetryMock();
+		const good = new BaseFeatureProviderMock(
+			telemetry,
+			new FetchResolver({ features: ['good'], assignmentContext: 'ctxGood', configs: [] }),
+			10,
+		);
+		const bad = new ThrowFeatureProvider(10);
+		const service = new ExperimentationServiceMock([good, bad], [], 100000, telemetry, new KeyValueStorageMock());
+
+		const enabled = await service.isFlightEnabledAsync('good');
+
+		expect(enabled).to.equal(true);
+		expect(telemetry.sharedProperties.get('AssignmentContextTelemetryEventName')).to.equal('ctxGood');
+	});
+
+	it('preserves cached features when all providers fail', async () => {
+		const telemetry = new ExperimentationTelemetryMock();
+		const storage = new KeyValueStorageMock();
+		storage.setValue('StorageKey', { features: ['cached'], assignmentContext: 'ctxCached', configs: [] });
+		const badA = new ThrowFeatureProvider(10);
+		const badB = new ThrowFeatureProvider(10);
+		const service = new ExperimentationServiceMock([badA, badB], [], 100000, telemetry, storage);
+
+		// Force a network fetch; every provider rejects.
+		await service.isFlightEnabledAsync('cached');
+
+		// Cache must be preserved (not overwritten with an empty set) when no provider succeeds.
+		expect(await service.isCachedFlightEnabled('cached')).to.equal(true);
+	});
+});
+
+// Regression: the custom `fetch` transport hook is used for the legacy endpoint (proxy
+// support), and a uniform `tas-call` event is emitted with the call outcome, extension
+// name, and the call's own assignment context.
+describe('Regression: legacy fetch hook + tas-call telemetry', () => {
+	const endpoint = 'https://example.test/tas';
+
+	it('uses the custom fetch hook and posts tas-call Success with assignmentContext', async () => {
+		const telemetry = new ExperimentationTelemetryMock();
+		let calledUrl: string | undefined;
+		let calledMethod: string | undefined;
+		const fetchFn = async (url: string, init: { method: 'GET' | 'POST' }) => {
+			calledUrl = url;
+			calledMethod = init.method;
+			return { status: 200, json: async () => ({ Configs: [{ Id: 'test', Parameters: { flightA: true } }], AssignmentContext: 'ctxLegacy' }) };
+		};
+		const provider = new TasApiFeatureProvider(new HttpClient(endpoint), telemetry, [], endpoint, fetchFn, 'my-ext');
+
+		const data = await provider.fetch();
+
+		expect(calledUrl).to.equal(endpoint);
+		expect(calledMethod).to.equal('GET');
+		expect(data.assignmentContext).to.equal('ctxLegacy');
+
+		const call = telemetry.postedEvents.find(e => e.eventName === TAS_CALL_EVENTNAME);
+		expect(call).to.not.equal(undefined);
+		expect(call!.args.get('callType')).to.equal('legacy');
+		expect(call!.args.get('outcome')).to.equal('Success');
+		expect(call!.args.get('extensionName')).to.equal('my-ext');
+		expect(call!.args.get('assignmentContext')).to.equal('ctxLegacy');
+	});
+
+	it('posts tas-call with ServerError outcome on a non-2xx response', async () => {
+		const telemetry = new ExperimentationTelemetryMock();
+		const fetchFn = async () => ({ status: 500, json: async () => ({}) });
+		const provider = new TasApiFeatureProvider(new HttpClient(endpoint), telemetry, [], endpoint, fetchFn, 'my-ext');
+
+		await expect(provider.fetch()).rejects.toBeDefined();
+
+		const call = telemetry.postedEvents.find(e => e.eventName === TAS_CALL_EVENTNAME);
+		expect(call).to.not.equal(undefined);
+		expect(call!.args.get('callType')).to.equal('legacy');
+		expect(call!.args.get('outcome')).to.equal('ServerError');
+	});
+});
+
+// Regression: mirror of the legacy coverage for the new assignments endpoint (POST).
+describe('Regression: assignments fetch hook + tas-call telemetry', () => {
+	const endpoint = 'https://example.test/assignments';
+
+	it('uses the custom fetch hook and posts tas-call Success with assignmentContext', async () => {
+		const telemetry = new ExperimentationTelemetryMock();
+		let calledUrl: string | undefined;
+		let calledMethod: string | undefined;
+		const fetchFn = async (url: string, init: { method: 'GET' | 'POST' }) => {
+			calledUrl = url;
+			calledMethod = init.method;
+			return { status: 200, json: async () => ({ featureVariables: { flagA: 'true' }, assignedVariants: [], dataVersion: 1, assignmentContext: 'ctxAssign' }) };
+		};
+		const provider = new AssignmentsApiFeatureProvider(new HttpClient(endpoint), telemetry, [new ExperimentationFilterProviderOneFilterMock()], endpoint, fetchFn, 'my-ext');
+
+		const data = await provider.fetch();
+
+		expect(calledUrl).to.equal(endpoint);
+		expect(calledMethod).to.equal('POST');
+		expect(data.assignmentContext).to.equal('ctxAssign');
+
+		const call = telemetry.postedEvents.find(e => e.eventName === TAS_CALL_EVENTNAME);
+		expect(call).to.not.equal(undefined);
+		expect(call!.args.get('callType')).to.equal('assignments');
+		expect(call!.args.get('outcome')).to.equal('Success');
+		expect(call!.args.get('extensionName')).to.equal('my-ext');
+		expect(call!.args.get('assignmentContext')).to.equal('ctxAssign');
+	});
+
+	it('posts tas-call with ServerError outcome and rejects on a non-2xx response', async () => {
+		const telemetry = new ExperimentationTelemetryMock();
+		const fetchFn = async () => ({ status: 500, json: async () => ({}) });
+		const provider = new AssignmentsApiFeatureProvider(new HttpClient(endpoint), telemetry, [new ExperimentationFilterProviderOneFilterMock()], endpoint, fetchFn, 'my-ext');
+
+		await expect(provider.fetch()).rejects.toBeDefined();
+
+		const call = telemetry.postedEvents.find(e => e.eventName === TAS_CALL_EVENTNAME);
+		expect(call).to.not.equal(undefined);
+		expect(call!.args.get('callType')).to.equal('assignments');
+		expect(call!.args.get('outcome')).to.equal('ServerError');
+	});
+});


### PR DESCRIPTION
## Summary

Fixes a reliability bug in the assignments-capable line (0.4.x) that broke legacy TAS in proxied environments, and adds a host-injectable transport plus per-call telemetry.

## Background

In 0.4.x the legacy endpoint switched to a built-in Node `https.get` with no proxy/agent handling. In a Node host behind a proxy (e.g. the VS Code extension host) the legacy call fails with a transport error.

## Changes

### `tas-client`
- **Unified custom transport (`fetch`)** — new `FetchFn` (`GET`/`POST`, optional body) on   `ExperimentationServiceConfig`, used for both the legacy and assignments endpoints, so  hosts can route TAS requests through their own proxy-aware networking stack. A
  per-endpoint `assignmentsFetch` still overrides for assignments. `AssignmentsFetchFn` /  `IAssignmentsFetchResponse` retained as deprecated aliases; added `IFetchResponse`.

- **`tas-call` telemetry** — uniform per-call event from both providers with  `callType` (legacy/assignments), `outcome` (Success/ServerError/NoResponse/GenericError),   `extensionName`, and the call's own `assignmentContext`. Complements
  `assignments-validation` (which keeps its variable/variant counts + data version).


## Validation

Verified end-to-end in a local VS Code build behind local proxy: legacy + assignments calls  oute through the host fetcher and succeed (200), `assignmentContext` is populated, and `tas-call` events report the correct `callType`/`outcome`/`extensionName` for both the
Copilot extension and core.