### PR TITLE
Expose unified fetch transport and extensionName

### DIFF
--- a/vscode-tas-client/README.md
+++ b/vscode-tas-client/README.md
@@ -3,29 +3,29 @@ vscode-tas-client is a package for querying and storing experiment information f
 
 ## Usage
 ### Initialization
-Get an `IExperimentationService` instance by calling `getExperimentationService(extensionName: string, extensionVersion: string, targetPopulation: TargetPopulation, telemetry: IExperimentationTelemetry, memento: vscode.Memento)`. 
+Get an `IExperimentationService` instance by calling `getExperimentationService(extensionName: string, extensionVersion: string, targetPopulation: TargetPopulation, telemetry: IExperimentationTelemetry, memento: vscode.Memento)`.
 
 > `extensionName`, `extensionVersion`, and `targetPopulation` are used to set traffic filter values.
 
 > It's recommended that you get `extensionName` and `extensionVersion` from your extension's `package.json`.
 
-`targetPopulation` is the ring the user belongs to - `Team`, `Internal`, `Insiders`, or `Public`. Most extensions determine what group a user belongs to based on a VS Code setting or a settings file. 
+`targetPopulation` is the ring the user belongs to - `Team`, `Internal`, `Insiders`, or `Public`. Most extensions determine what group a user belongs to based on a VS Code setting or a settings file.
 
 `telemetry` is used to send telemetry for [counterfactual logging](https://dev.azure.com/experimentation/Analysis%20and%20Experimentation/_wiki/wikis/AnE.wiki/4228/Demystifying-Counterfactual-Logging) purposes and to attach common properties to all telemetry events, which enables the computation of an experiment scorecard. The extension sends an event `query-expfeature` the first time a given flight or treatment variable is requested and attaches the common properties `vscode.abexp.features` and `abexp.assignmentcontext` to all events.
 > note: all the telemetry events sent by the extension and common properties have already been GDPR classified.
 
-`memento` is the VS Code memento storage for your extension, which can be accessed via `context.globalState`, where `context` is the `vscode.ExtensionContext` that VS Code passes your extension on activation. It's used to cache info from the TAS. 
+`memento` is the VS Code memento storage for your extension, which can be accessed via `context.globalState`, where `context` is the `vscode.ExtensionContext` that VS Code passes your extension on activation. It's used to cache info from the TAS.
 
-There's also a `getExperimentationServiceAsync` function that behaves identically to `getExperimentationService` except it `await`s the returned `IExperimentationService`'s `initializePromise` before returning. This ensures that cached info from the TAS is loaded. Since this simply involves reading VS Code memento storage, it usually takes <10ms. 
+There's also a `getExperimentationServiceAsync` function that behaves identically to `getExperimentationService` except it `await`s the returned `IExperimentationService`'s `initializePromise` before returning. This ensures that cached info from the TAS is loaded. Since this simply involves reading VS Code memento storage, it usually takes <10ms.
 
 ### Use
 Once you have an instance of `IExperimentationService` you can call `getTreatmentVariable(configId: string, name: string)` to get the value of a treatment variable. `configId` is always `vscode` and `name` is the name of the treatment variable that you defined in control tower when you set up your experiment.
 
-> note: if you haven't awaited the `IExperimentationService`'s `initializePromise`, or, equivallently, used `getExperimentationServiceAsync` to get the `IExperimentationService` instance, you need to use `getTreatmentVariableAsync`. 
+> note: if you haven't awaited the `IExperimentationService`'s `initializePromise`, or, equivallently, used `getExperimentationServiceAsync` to get the `IExperimentationService` instance, you need to use `getTreatmentVariableAsync`.
 
 ## Details
 ### Telemetry
-vscode-tas-client will handle sending all needed telemetry to analyze your experiment. Specifically, it sends an event `query-expfeature` the first time a given flight or treatment variable is requested (for counterfactual logging purposes) and attaches the common properties `vscode.abexp.features` - a list of treatment variables - and `abexp.assignmentcontext` - a list of flight names - to all telemetry events your extension sends. 
+vscode-tas-client will handle sending all needed telemetry to analyze your experiment. Specifically, it sends an event `query-expfeature` the first time a given flight or treatment variable is requested (for counterfactual logging purposes) and attaches the common properties `vscode.abexp.features` - a list of treatment variables - and `abexp.assignmentcontext` - a list of flight names - to all telemetry events your extension sends.
 
 ### Background refresh of treatment variables
 The vscode-tas-client package makes an HTTP request to the TAS when you first call `getExperimentationService`, and then every 30 minutes after that. The new information from the `TAS` is cached in VS Code memento storage.
@@ -35,5 +35,15 @@ To avoid changing the user experience mid-session, after requesting the value of
 
 A few examples to clarify:
 - *Your extension calls `getExperimentationServiceAsync` and then immediately after calls `getTreatmentVariable`. Later in the session, you call `getTreatmentVariable` again*. vscode-tas-client will make a request to the TAS as soon as you call `getExperimentationServiceAsync`. However, this request usually takes 1-5s to complete, so the call to `getTreatmentVariable` is made before it does. This means that the `getTreatmentVariable` request will be serviced using cached data from the last request to the TAS. Because this data was used to service the first request, it will also be used to service the second request, even though the HTTP request to the TAS has returned by this time. However, the new data from the TAS isn't thrown away, it's used to update the cache so that the next VS Code session will use the updated data, even with the same sequence of events.
-- *Your extension calls `getExperimentationServiceAsync` and then immediately after calls `getTreatmentVariable`. Later in the session, you call `getTreatmentVariableAsync`*. vscode-tas-client will make a request to the TAS as soon as you call `getExperimentationServiceAsync`. However, this request usually takes 1-5s to complete, so the call to `getTreatmentVariable` is made before it does. This means that the `getTreatmentVariable` request will be serviced using cached data from the last request to the TAS. The second request, `getTreatmentVariableAsync` will result in waiting on an HTTP request to the TAS. The updated data will be used to service the request and the cache will be updated. Note this means the user could change flights, or become part of a new flight, mid-session. 
+- *Your extension calls `getExperimentationServiceAsync` and then immediately after calls `getTreatmentVariable`. Later in the session, you call `getTreatmentVariableAsync`*. vscode-tas-client will make a request to the TAS as soon as you call `getExperimentationServiceAsync`. However, this request usually takes 1-5s to complete, so the call to `getTreatmentVariable` is made before it does. This means that the `getTreatmentVariable` request will be serviced using cached data from the last request to the TAS. The second request, `getTreatmentVariableAsync` will result in waiting on an HTTP request to the TAS. The updated data will be used to service the request and the cache will be updated. Note this means the user could change flights, or become part of a new flight, mid-session.
 - *Your extension calls `getExperimentationServiceAsync` and then ~1 minute later calls `getTreatmentVariable`*. vscode-tas-client will make a request to the TAS as soon as you call `getExperimentationServiceAsync`. Because this request completes before the call to `getExperimentationService`, the freshly fetched data is used.
+
+
+# 0.4.3
+
+## Custom transport & call telemetry
+
+`getExperimentationServiceFromConfig` accepts two optional fields:
+
+- `fetch` — a custom transport used for **both** the legacy and assignments endpoints, letting you route TAS requests through your own (e.g. proxy-aware) networking stack instead of the built-in HTTP client. A per-endpoint `assignmentsFetch` still overrides it for the assignments request.
+- `extensionName` — a caller name attached to the `tas-call` telemetry event, which reports `callType` (`legacy`/`assignments`), `outcome`, `extensionName`, and the call's `assignmentContext` for each TAS call.

--- a/vscode-tas-client/README.md
+++ b/vscode-tas-client/README.md
@@ -39,11 +39,11 @@ A few examples to clarify:
 - *Your extension calls `getExperimentationServiceAsync` and then ~1 minute later calls `getTreatmentVariable`*. vscode-tas-client will make a request to the TAS as soon as you call `getExperimentationServiceAsync`. Because this request completes before the call to `getExperimentationService`, the freshly fetched data is used.
 
 
-# 0.4.3
+# 0.3.1
 
 ## Custom transport & call telemetry
 
-`getExperimentationServiceFromConfig` accepts two optional fields:
+`getExperimentationServiceFromConfig` accepts an optional `fetch` field and uses its existing required `extensionName` field for call telemetry:
 
 - `fetch` — a custom transport used for **both** the legacy and assignments endpoints, letting you route TAS requests through your own (e.g. proxy-aware) networking stack instead of the built-in HTTP client. A per-endpoint `assignmentsFetch` still overrides it for the assignments request.
 - `extensionName` — a caller name attached to the `tas-call` telemetry event, which reports `callType` (`legacy`/`assignments`), `outcome`, `extensionName`, and the call's `assignmentContext` for each TAS call.

--- a/vscode-tas-client/package-lock.json
+++ b/vscode-tas-client/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "vscode-tas-client",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-tas-client",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "tas-client": "^0.4.2"
+        "tas-client": "^0.4.3"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -2681,9 +2681,9 @@
       }
     },
     "node_modules/tas-client": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.4.2.tgz",
-      "integrity": "sha512-6I+52uvsOdqgPsyvlXSz+KtydfnnLngTnMeVnoXgEYMIFxqRT6tWX2IdH/O5JocF4Z0JZDB3ejTLbJMSb6pEdg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.4.3.tgz",
+      "integrity": "sha512-6bqNgMv7ys5PL6Zqz+EoR8J5KrhAGFjodUPkcpM80DHFakKiWcjqKiID5qxsssC/E70fcgYYWPAUK7CWS29b+Q==",
       "license": "MIT",
       "engines": {
         "node": ">=22"

--- a/vscode-tas-client/package.json
+++ b/vscode-tas-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-tas-client",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "",
   "main": "./out/index.js",
   "types": "./out/index.d.ts",
@@ -37,6 +37,6 @@
     "vitest": "^4.1.8"
   },
   "dependencies": {
-    "tas-client": "^0.4.2"
+    "tas-client": "^0.4.3"
   }
 }

--- a/vscode-tas-client/src/index.ts
+++ b/vscode-tas-client/src/index.ts
@@ -10,6 +10,8 @@ export {
     IExperimentationFilterProvider,
     AssignmentsFetchFn,
     IAssignmentsFetchResponse,
+    FetchFn,
+    IFetchResponse,
 } from 'tas-client';
 export {
     getExperimentationService,

--- a/vscode-tas-client/src/vscode-tas-client/VSCodeTasClient.ts
+++ b/vscode-tas-client/src/vscode-tas-client/VSCodeTasClient.ts
@@ -10,6 +10,7 @@ import {
     IExperimentationTelemetry,
     IExperimentationFilterProvider,
     AssignmentsFetchFn,
+    FetchFn,
 } from 'tas-client';
 import * as vscode from 'vscode';
 import { MementoKeyValueStorage } from './MementoKeyValueStorage';
@@ -52,6 +53,12 @@ export interface ExperimentationConfig {
      * service), used instead of the built-in HTTP client for that request.
      */
     assignmentsFetch?: AssignmentsFetchFn;
+    /**
+     * Optional custom transport used for both the legacy endpoint (GET) and the assignments
+     * endpoint (POST) (e.g. the VS Code fetcher service), so both requests get proxy handling.
+     * A per-endpoint {@link assignmentsFetch}, if set, takes precedence for assignments.
+     */
+    fetch?: FetchFn;
 }
 
 /**
@@ -98,6 +105,8 @@ export function getExperimentationServiceFromConfig(
         assignmentContextTelemetryPropertyName: assignmentContextTelemetryPropertyName,
         telemetryEventName: telemetryEventName,
         endpoint: endpoint,
+        extensionName: config.extensionName,
+        fetch: config.fetch,
         assignmentsEndpoint: config.assignmentsEndpoint,
         assignmentsFilterProviders: assignmentsFilterProviders,
         assignmentsFetch: config.assignmentsFetch,


### PR DESCRIPTION
## What
Wires the `vscode-tas-client` wrapper up to the unified `fetch` transport and `extensionName` call-telemetry hook added in `tas-client@0.4.3`.

## Changes
- **Consume `tas-client@0.4.3`**: bump dependency `^0.4.2` → `^0.4.3` and package  version `0.3.0` → `0.3.1` (`package.json`, `package-lock.json`).
- **`ExperimentationConfig.fetch`**: new optional `FetchFn` transport used for **both**   the legacy (GET) and assignments (POST) endpoints, so hosts can route TAS requests  through their own proxy-aware networking stack. A per-endpoint `assignmentsFetch`  still takes precedence for the assignments request.
- **Pass-through wiring**: forward `config.fetch` and `config.extensionName` into  `ExperimentationService`. `extensionName` is attached to the new `tas-call` telemetry  event (`callType`, `outcome`, `extensionName`, `assignmentContext`).
- **Docs**: add a `0.4.3` section to the README documenting `fetch` and `extensionName`